### PR TITLE
Add installation requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ setup(
     url='https://github.com/facelessuser/wcmatch',
     packages=find_packages(exclude=['tests', 'tools']),
     setup_requires=get_requirements("requirements/setup.txt"),
+    install_requires=get_requirements("requirements/setup.txt"),
     license='MIT License',
     classifiers=[
         'Development Status :: %s' % DEVSTATUS,


### PR DESCRIPTION
I had to manually install backrefs and bracex to get this running, after installing wcmatch with `pip3 install wcmatch` - I believe install_requires is the missing piece.

Looks like a really interesting lib!