### PR TITLE
Test Python38

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,16 @@ matrix:
       dist: xenial
       env: TOXENV=py37
       sudo: true
+    - python: 3.8-dev
+      dist: xenial
+      env: TOXENV=py38
+      sudo: true
     - python: 3.6
       env: TOXENV=lint
     - python: 3.6
       env: TOXENV=documents
+  allow_failures:
+    - python: 3.8-dev
 
 # addons:
 #   apt:

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 skipsdist=true
 envlist=
-    {py34,py35,py36,py37},
+    {py34,py35,py36,py37,py38},
     lint
 
 [testenv]


### PR DESCRIPTION
Target Python38 for testing as this module may be senstive to changes in the re module. Test, but do not fail on Py38 as we are only hoping to expose issues, not hold up merges or releases.