### PR TITLE
Glob bug fixes

### DIFF
--- a/docs/src/markdown/changelog.md
+++ b/docs/src/markdown/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 3.0.2
+
+- **FIX**: Fix an offset issue when processing an absolute path pattern in `glob` on Linux or macOS.
+- **FIX**: Fix an issue where the `glob` command would use `GLOBSTAR` logic on `**` even when `GLOBSTAR` was disabled.
+
 ## 3.0.1
 
 - **FIX**: In the `WcMatch` class, defer hidden file check until after the file or directory is compared against patterns to potentially avoid calling hidden if the pattern doesn't match. The reduced `lstat` calls improve performance.

--- a/wcmatch/__meta__.py
+++ b/wcmatch/__meta__.py
@@ -186,5 +186,5 @@ def parse_version(ver, pre=False):
     return Version(major, minor, micro, release, pre, post, dev)
 
 
-__version_info__ = Version(3, 0, 1, "final")
+__version_info__ = Version(3, 0, 2, "final")
 __version__ = __version_info__._get_canonical()

--- a/wcmatch/_wcparse.py
+++ b/wcmatch/_wcparse.py
@@ -290,6 +290,7 @@ class WcPathSplit(object):
         self.unix = is_unix_style(flags)
         self.flags = flags
         self.pattern = util.norm_pattern(pattern, not self.unix, flags & RAWCHARS)
+        self.globstar = bool(flags & GLOBSTAR)
         if is_negative(self.pattern, flags):  # pragma: no cover
             # This isn't really used, but we'll keep it around
             # in case we find a reason to directly send inverse patterns
@@ -404,7 +405,7 @@ class WcPathSplit(object):
         if l and value in (b'', ''):
             return
 
-        globstar = value in (b'**', '**')
+        globstar = value in (b'**', '**') and self.globstar
         magic = self.is_magic(value)
         if magic:
             value = compile(value, self.flags)
@@ -438,8 +439,8 @@ class WcPathSplit(object):
                 i.advance(2)
         elif not self.win_drive_detect and pattern.startswith('/'):
             parts.append(WcGlob(b'/' if self.is_bytes else '/', False, False, True, True))
-            start = 1
-            i.advance(2)
+            start = 0
+            i.advance(1)
 
         for c in i:
             if self.extend and c in EXT_TYPES and self.parse_extend(c, i):


### PR DESCRIPTION
- Fix an offset issue when processing an absolute path pattern in `glob`
on Linux or macOS.
- Fix an issue where the `glob` command would use `GLOBSTAR` logic on
`**` even when `GLOBSTAR` was disabled.