### PR TITLE
Don't deprecate exclusion defaults, but provide an official flag

### DIFF
--- a/docs/src/markdown/changelog.md
+++ b/docs/src/markdown/changelog.md
@@ -8,7 +8,7 @@
 - **NEW**: Add `NODIR` that causes `glob` matchers and crawlers to only match and return files.
 - **NEW**: Exclusion patterns (enabled with `NEGATE`) now always enable `DOTALL` in the exclusion patterns. They also will match symlinks in `**` patterns. Only non `NEGATE` patterns that are paired with a `NEGATE` pattern are subject to symlinks and dot rules. Exclusion patterns themselves allow dots and symlinks to make filtering easier.
 - **NEW**: Exclusion patterns no longer provide a default regular pattern if one is not applied. Exclusion patterns are
-meant to filter the results of normal patterns. You can either use the `SPLIT` flag and provide a pattern with your default ('default_pattern|!exclusion'), or feed in a list of multiple patterns instead of a single string (`['default_pattern', '!exclusion']`). If you really need the old behavior, you can use the `NEGDEFAULT` flag which will provide a default of `**` which is subject to the `GLOBSTAR` flag. `NEGDEFAULT` will raise a deprecation warning and will be removed in the future.
+meant to filter the results of normal patterns. You can either use the `SPLIT` flag and provide a pattern with your default ('default_pattern|!exclusion'), or feed in a list of multiple patterns instead of a single string (`['default_pattern', '!exclusion']`). If you really need the old behavior, you can use the `NEGATEALL` flag which will provide a default inclusion pattern that matches all files.
 - **NEW**: Translate now outputs exclusion patterns so that if they match, the file is excluded. This is opposite logic to how it used to be, but is more efficient.
 - **FIX**: An empty pattern in `glob` should not match slashes.
 

--- a/docs/src/markdown/fnmatch.md
+++ b/docs/src/markdown/fnmatch.md
@@ -77,6 +77,16 @@ True
 False
 ```
 
+As mentioned, exclusion patterns need to be applied to a non-exclusion pattern to work, but if it is desired, you can force exclusion patterns to assume all files match unless excluded with the [`NEGATEALL`](#fnmatchnegateall) flag. Essentially, it means if you use a pattern such as `!*.md`, it will assume two pattern were given: `*` and `!*.md`.
+
+```pycon3
+>>> from wcmatch import fnmatch
+>>> fnmatch.fnmatch('test.py', r'!*.py', flags=fnmatch.NEGATE | fnamtch.SPLIT)
+False
+>>> fnmatch.fnmatch('test.txt', r'!*.py', flags=fnmatch.NEGATE | fnamtch.SPLIT)
+True
+```
+
 #### `fnmatch.filter`
 
 ```py3
@@ -144,13 +154,19 @@ def translate(patterns, *, flags=0):
 
 #### `fnmatch.NEGATE, fnmatch.N` {: #fnmatchnegate}
 
-`NEGATE` causes patterns that start with `!` to be treated as exclusion matches. A pattern of `!*.py` would match any file but Python files. If used with [`EXTMATCH`](#fnmatchextmatch), patterns like `!(inverse|pattern)` will be mistakenly parsed as an exclusion pattern instead of an inverse `extmatch` group.  See [`MINUSNEGATE`](#fnmatchminusnegate) for an alternative syntax that plays nice with `EXTMATCH`.
+`NEGATE` causes patterns that start with `!` to be treated as exclusion patterns. A pattern of `!*.py` would match any file but Python files. Exclusion patterns cannot be used by themselves though, and must be paired with a normal, inclusion pattern, either by utilizing the [`SPLIT`](#fnmatchsplit) flag, or providing multiple patterns in a list. Assuming the `SPLIT` flag, this means using it in a pattern such as `inclusion|!exclusion`.
 
-!!! warning "Change 4.0"
-    In 4.0, `NEGATE` now requires a non-exclusion pattern to be paired with it or it will match nothing. You can either
-    use [`SPLIT`](#fnmatchSPLIT), or feed in a list of multiple patterns instead of a single string. If you really
-    need the old behavior, you can use the `NEGDEFAULT` flag which will provide a default of `**` which is subject to
-    the `GLOBSTAR` flag. `NEGDEFAULT` will raise a deprecation warning and will be removed in the future.
+If it is desired, you can force exclusion patterns, when no inclusion pattern is provided, to assume all files match unless the file matches the excluded pattern. This is done with the [`NEGATEALL`](#fnmatchnegateall) flag.
+
+If used with the extended glob feature, patterns like `!(inverse|pattern)` will be mistakenly parsed as an exclusion pattern instead of as an inverse extended glob group.  See [`MINUSNEGATE`](#fnmatchminusgate) for an alternative syntax that plays nice with extended glob.
+
+!!! warning "Changes 4.0"
+    In 4.0, `NEGATE` now requires a non-exclusion pattern to be paired with it or it will match nothing. If you really
+    need something similar to the old behavior, that would assume a default inclusion pattern, you can use the [`NEGATEALL`](#fnmatchnegateall).
+
+#### `glob.NEGATEALL, glob.A`
+
+`NEGATEALL` can force exclusion patterns, when no inclusion pattern is provided, to assume all files match unless the file matches the excluded pattern. Essentially, it means if you use a pattern such as `!*.md`, it will assume a pattern of `*|!*.md` (assuming the use of the [`SPLIT`](#fnmatchsplit) flag).
 
 #### `fnmatch.MINUSNEGATE, fnmatch.M` {: #fnmatchminusnegate}
 

--- a/tests/test_fnmatch.py
+++ b/tests/test_fnmatch.py
@@ -476,6 +476,18 @@ class TestFnMatchTranslate(unittest.TestCase):
         with pytest.raises(SyntaxError):
             fnmatch.translate(r'test\N{', flags=self.flags | fnmatch.R)
 
+    def test_default_compile(self):
+        """Test default with exclusion."""
+
+        self.assertTrue(fnmatch.fnmatch('name', '!test', flags=fnmatch.N | fnmatch.A))
+        self.assertTrue(fnmatch.fnmatch(b'name', b'!test', flags=fnmatch.N | fnmatch.A))
+
+    def test_default_translate(self):
+        """Test default with exclusion in translation."""
+
+        self.assertTrue(len(fnmatch.translate('!test', flags=fnmatch.N | fnmatch.A)[0]) == 1)
+        self.assertTrue(len(fnmatch.translate(b'!test', flags=fnmatch.N | fnmatch.A)[0]) == 1)
+
 
 class TestDeprecated(unittest.TestCase):
     """Test deprecated."""
@@ -491,47 +503,3 @@ class TestDeprecated(unittest.TestCase):
             self.assertTrue(len(w) == 1)
             self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
             self.assertTrue(patterns, ['test', 'test'])
-
-    def test_default_compile(self):
-        """Test deprecated default."""
-
-        with warnings.catch_warnings(record=True) as w:
-            # Cause all warnings to always be triggered.
-            warnings.simplefilter("always")
-
-            self.assertTrue(fnmatch.fnmatch('name', '!test', flags=fnmatch.N | fnmatch.NEGDEFAULT))
-            self.assertTrue(len(w) == 1)
-            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
-
-    def test_default_compile_bytes(self):
-        """Test deprecated default bytes."""
-
-        with warnings.catch_warnings(record=True) as w:
-            # Cause all warnings to always be triggered.
-            warnings.simplefilter("always")
-
-            self.assertTrue(fnmatch.fnmatch(b'name', b'!test', flags=fnmatch.N | fnmatch.NEGDEFAULT))
-            self.assertTrue(len(w) == 1)
-            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
-
-    def test_default_translate(self):
-        """Test deprecated default."""
-
-        with warnings.catch_warnings(record=True) as w:
-            # Cause all warnings to always be triggered.
-            warnings.simplefilter("always")
-
-            fnmatch.translate('!test', flags=fnmatch.N | fnmatch.NEGDEFAULT)
-            self.assertTrue(len(w) == 1)
-            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
-
-    def test_default_translate_bytes(self):
-        """Test deprecated default bytes."""
-
-        with warnings.catch_warnings(record=True) as w:
-            # Cause all warnings to always be triggered.
-            warnings.simplefilter("always")
-
-            fnmatch.translate(b'!test', flags=fnmatch.N | fnmatch.NEGDEFAULT)
-            self.assertTrue(len(w) == 1)
-            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))

--- a/tests/test_glob.py
+++ b/tests/test_glob.py
@@ -837,6 +837,20 @@ class Testglob(_TestGlob):
 
         self.eval_glob_cases(case)
 
+    def test_negateall(self):
+        """Negate applied to all files."""
+
+        with change_cwd(self.tempdir):
+            for file in glob.glob('!**/', flags=glob.N | glob.NEGATEALL | glob.G):
+                self.assertFalse(os.path.isdir(file))
+
+    def test_negateall_bytes(self):
+        """Negate applied to all files."""
+
+        with change_cwd(self.tempdir):
+            for file in glob.glob(b'!**/', flags=glob.N | glob.NEGATEALL | glob.G):
+                self.assertFalse(os.path.isdir(file))
+
 
 class TestGlobMarked(Testglob):
     """Test glob marked."""
@@ -1060,25 +1074,3 @@ class TestDeprecated(unittest.TestCase):
             self.assertTrue(len(w) == 1)
             self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
             self.assertTrue(patterns, ['test', 'test'])
-
-    def test_default(self):
-        """Test deprecated default."""
-
-        with warnings.catch_warnings(record=True) as w:
-            # Cause all warnings to always be triggered.
-            warnings.simplefilter("always")
-
-            glob.glob('!name', flags=glob.N | glob.NEGDEFAULT)
-            self.assertTrue(len(w) != 0)
-            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
-
-    def test_default_bytes(self):
-        """Test deprecated default bytes."""
-
-        with warnings.catch_warnings(record=True) as w:
-            # Cause all warnings to always be triggered.
-            warnings.simplefilter("always")
-
-            glob.glob(b'!name', flags=glob.N | glob.NEGDEFAULT)
-            self.assertTrue(len(w) != 0)
-            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))

--- a/wcmatch/fnmatch.py
+++ b/wcmatch/fnmatch.py
@@ -26,8 +26,8 @@ from . import _wcparse
 __all__ = (
     "EXTMATCH", "FORCECASE", "IGNORECASE", "RAWCHARS",
     "NEGATE", "MINUSNEGATE", "DOTMATCH", "BRACE", "SPLIT",
-    "NEGDEFAULT",
-    "F", "I", "R", "N", "M", "D", "E", "S", "B",
+    "NEGATEALL",
+    "F", "I", "R", "N", "M", "D", "E", "S", "B", "A",
     "translate", "fnmatch", "filter", "fnsplit"
 )
 
@@ -40,7 +40,7 @@ D = DOTMATCH = _wcparse.DOTMATCH
 E = EXTMATCH = _wcparse.EXTMATCH
 B = BRACE = _wcparse.BRACE
 S = SPLIT = _wcparse.SPLIT
-NEGDEFAULT = _wcparse.NEGDEFAULT
+A = NEGATEALL = _wcparse.NEGATEALL
 
 FLAG_MASK = (
     FORCECASE |
@@ -52,7 +52,7 @@ FLAG_MASK = (
     EXTMATCH |
     BRACE |
     SPLIT |
-    NEGDEFAULT
+    NEGATEALL
 )
 
 

--- a/wcmatch/wcmatch.py
+++ b/wcmatch/wcmatch.py
@@ -28,7 +28,7 @@ from . import util
 __all__ = (
     "FORCECASE", "IGNORECASE", "RAWCHARS", "FILEPATHNAME", "DIRPATHNAME",
     "EXTMATCH", "GLOBSTAR", "BRACE", "MINUSNEGATE", "SYMLINKS", "HIDDEN", "RECURSIVE",
-    "MATCHBASE", "NEGDEFAULT",
+    "MATCHBASE",
     "F", "I", "R", "P", "E", "G", "M", "DP", "FP", "SL", "HD", "RV", "X", "B",
     "WcMatch"
 )
@@ -41,7 +41,6 @@ G = GLOBSTAR = _wcparse.GLOBSTAR
 B = BRACE = _wcparse.BRACE
 M = MINUSNEGATE = _wcparse.MINUSNEGATE
 X = MATCHBASE = _wcparse.MATCHBASE
-NEGDEFAULT = _wcparse.NEGDEFAULT
 
 # Control `PATHNAME` individually for folder exclude and files
 DP = DIRPATHNAME = 0x10000
@@ -66,8 +65,7 @@ FLAG_MASK = (
     SYMLINKS |
     HIDDEN |
     RECURSIVE |
-    MATCHBASE |
-    NEGDEFAULT
+    MATCHBASE
 )
 
 
@@ -105,7 +103,7 @@ class WcMatch(object):
         """Parse flags."""
 
         self.flags = flags & FLAG_MASK
-        self.flags |= _wcparse.NEGATE | _wcparse.DOTMATCH
+        self.flags |= _wcparse.NEGATE | _wcparse.DOTMATCH | _wcparse.NEGATEALL
         self.follow_links = bool(self.flags & SYMLINKS)
         self.show_hidden = bool(self.flags & HIDDEN)
         self.recursive = bool(self.flags & RECURSIVE)
@@ -137,7 +135,6 @@ class WcMatch(object):
             file_pattern = self._compile_wildcard(file_pattern, self.file_pathname)
 
         if not isinstance(folder_exclude_pattern, _wcparse.WcRegexp):
-
             folder_exclude_pattern = self._compile_wildcard(folder_exclude_pattern, self.dir_pathname)
 
         return file_pattern, folder_exclude_pattern


### PR DESCRIPTION
Instead of deprecating defaults for exclusions, make an official flag
called NEGATEALL (rename from NEGDEFAULT). But in paths, always apply
`GLOBSTAR` to the default pattern.