### PR TITLE
Windows case sensitivity flag

### DIFF
--- a/docs/src/markdown/changelog.md
+++ b/docs/src/markdown/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 4.3.0
+
+- **NEW**: Add `CASE` flag which allows for case sensitive paths on Linux, macOS, and Windows. Windows drive letters and UNC `//host-name/share-name/` portion are still treated insensitively, but all directories will be treated with case sensitivity.
+- **NEW**: With the recent addition of `CASE` and `FORCEUNIX`, `FORCECASE` is no longer needed. Deprecate `FORCECASE` which will be removed at some future point.
+
 ## 4.2.0
 
 - **NEW**: Drop Python 3.4 support.

--- a/docs/src/markdown/fnmatch.md
+++ b/docs/src/markdown/fnmatch.md
@@ -138,11 +138,25 @@ def translate(patterns, *, flags=0):
 
 `FORCECASE` forces case sensitivity. `FORCECASE` has higher priority than [`IGNORECASE`](#fnmatchignorecase).
 
-On Windows, this will force names to be treated like Linux/Unix names, and slashes will not be normalized. It is recommended to use [`FORCEUNIX`](#fnmatchforceunix) if the desire is to force Linux/Unix style logic. It is more intuitive when reading the code and can allow combinations with `IGNORECASE` if a case insensitive Linux/Unix style is preferred. Currently, Windows is the only system that is treated case insensitively by default.
+On Windows, this will force names to be treated like Linux/Unix names, and slashes will not be normalized.
+
+!!! warning "Deprecated 4.3.0"
+    `FORCECASE` has been deprecated as of 4.3.0.
+
+    It is recommended to use [`FORCEUNIX`](#fnmatchforceunix) if the desire is to force Linux/Unix style logic. It is more intuitive when reading the code and can allow combinations with `IGNORECASE` if a case insensitive Linux/Unix style is preferred. Currently, Windows is the only system that is treated case insensitively by default.
+
+    If you'd like to force case sensitivity, even on Windows, it is recommended to use [`CASE`](#fnmatchcase). `CASE` can also be paired with the [`FORCEWIN`](#fnmatchforceunix) flag if desired.
+
+#### `fnmatch.CASE, fnmatch.C` {: #fnmatchcase}
+
+`CASE` forces case sensitivity. `CASE` has higher priority than [`IGNORECASE`](#fnmatchignorecase).
+
+!!! new "New 4.3.0"
+    `CASE` is new in 4.3.0.
 
 #### `fnmatch.IGNORECASE, fnmatch.I` {: #fnmatchignorecase}
 
-`IGNORECASE` forces case insensitivity. [`FORCECASE`](#fnmatchforcecase) has higher priority than `IGNORECASE`.
+`IGNORECASE` forces case insensitivity. [`CASE`](#fnmatchcase) has higher priority than `IGNORECASE`.
 
 #### `fnmatch.RAWCHARS, fnmatch.R` {: #fnmatchrawchars}
 
@@ -154,13 +168,13 @@ On Windows, this will force names to be treated like Linux/Unix names, and slash
 
 If it is desired, you can force exclusion patterns, when no inclusion pattern is provided, to assume all files match unless the file matches the excluded pattern. This is done with the [`NEGATEALL`](#fnmatchnegateall) flag.
 
-If used with the extended glob feature, patterns like `!(inverse|pattern)` will be mistakenly parsed as an exclusion pattern instead of as an inverse extended glob group.  See [`MINUSNEGATE`](#fnmatchminusgate) for an alternative syntax that plays nice with extended glob.
+If used with the extended match feature, patterns like `!(inverse|pattern)` will be mistakenly parsed as an exclusion pattern instead of as an inverse extended glob group.  See [`MINUSNEGATE`](#fnmatchminusgate) for an alternative syntax that plays nice with extended glob.
 
 !!! warning "Changes 4.0"
     In 4.0, `NEGATE` now requires a non-exclusion pattern to be paired with it or it will match nothing. If you really
     need something similar to the old behavior, that would assume a default inclusion pattern, you can use the [`NEGATEALL`](#fnmatchnegateall).
 
-#### `fnmatch.NEGATEALL, glob.A` {: #fnmatchnegateall}
+#### `fnmatch.NEGATEALL, fnmatch.A` {: #fnmatchnegateall}
 
 `NEGATEALL` can force exclusion patterns, when no inclusion pattern is provided, to assume all files match unless the file matches the excluded pattern. Essentially, it means if you use a pattern such as `!*.md`, it will assume two patterns were given: `*` and `!*.md`, where `!*.md` is applied to the results of `*`.
 
@@ -172,7 +186,7 @@ When `MINUSNEGATE` is used with [`NEGATE`](#fnmatchnegate), exclusion patterns a
 
 #### `fnmatch.DOTMATCH, fnmatch.D` {: #fnmatchdotmatch}
 
-By default, [`glob`](#fnmatchfnmatch) and related functions will not match file or directory names that start with dot `.` unless matched with a literal dot. `DOTMATCH` allows the meta characters (such as `*`) to match dots like any other character. Dots will not be matched in `[]`, `*`, or `?`.
+By default, [`fnmatch`](#fnmatchfnmatch) and related functions will not match file or directory names that start with dot `.` unless matched with a literal dot. `DOTMATCH` allows the meta characters (such as `*`) to match dots like any other character. Dots will not be matched in `[]`, `*`, or `?`.
 
 #### `fnmatch.EXTMATCH, fnmatch.E` {: #fnmatchextmatch}
 
@@ -201,8 +215,6 @@ True
 #### `fnmatch.FORCEWIN, fnmatch.W` {: #fnmatchforcewin}
 
 `FORCEWIN` will force Windows name and case logic to be used on Linux/Unix systems. It will also cause slashes to be normalized. This is great if you need to match Windows specific names on a Linux/Unix system.
-
-When using `FORCEWIN`, [`FORCECASE`](#fnmatchforcecase) will be ignored as paths on Windows are not case sensitive.
 
 If `FORCEWIN` is used along side [`FORCEUNIX`](#fnmatchforceunix), both will be ignored.
 

--- a/docs/src/markdown/wcmatch.md
+++ b/docs/src/markdown/wcmatch.md
@@ -279,9 +279,22 @@ is called on every new `match` call.
 
 `FORCECASE` does not apply to Windows systems.
 
+!!! warning "Deprecated 4.3.0"
+
+    `FORCECASE` is deprecated in 4.3.0.
+
+    If you'd like to force case sensitivity, even on Windows, it is recommended to use [`CASE`](#wcmatchcase).
+
+#### `wcmatch.CASE, wcmatch.C` {: #wcmatchcase}
+
+`CASE` forces case sensitivity. `CASE` has higher priority than [`IGNORECASE`](#wcmatchignorecase).
+
+!!! new "New 4.3.0"
+    `CASE` is new in 4.3.0.
+
 #### `wcmatch.IGNORECASE, wcmatch.I` {: #wcmatchignorecase}
 
-`IGNORECASE` forces case insensitive searches. `FORCECASE` has higher priority than [`IGNORECASE`](#wcmatchignorecase).
+`IGNORECASE` forces case insensitive searches. [`CASE`](#wcmatchcase) has higher priority than `IGNORECASE`.
 
 #### `wcmatch.RAWCHARS, wcmatch.R` {: #wcmatchrawchars}
 

--- a/tests/test_fnmatch.py
+++ b/tests/test_fnmatch.py
@@ -529,3 +529,16 @@ class TestDeprecated(unittest.TestCase):
             self.assertTrue(len(w) == 1)
             self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
             self.assertTrue(patterns, ['test', 'test'])
+
+    def test_forcecase(self):
+        """Test deprecation of force case flag."""
+
+        with warnings.catch_warnings(record=True) as w:
+            # Cause all warnings to always be triggered.
+            warnings.simplefilter("always")
+
+            fnmatch.translate('*', flags=fnmatch.F),
+            fnmatch.fnmatch('path', "*", flags=fnmatch.F)
+            fnmatch.filter(['path'], "*", flags=fnmatch.F)
+            self.assertEqual(len(w), 3)
+            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))

--- a/tests/test_fnmatch.py
+++ b/tests/test_fnmatch.py
@@ -56,13 +56,30 @@ class TestFnMatch:
         ['foo*', '\nfoo', False, 0],
         ['*', '\n', True, 0],
 
-        # Force case: General
+        # Case: General
+        ['abc', 'abc', True, fnmatch.C],
+        ['abc', 'AbC', False, fnmatch.C],
+        ['AbC', 'abc', False, fnmatch.C],
+        ['AbC', 'AbC', True, fnmatch.C],
+
+        # Case and Force Unix: slash conventions
+        ['usr/bin', 'usr/bin', True, fnmatch.C | fnmatch.U],
+        ['usr/bin', 'usr\\bin', False, fnmatch.C | fnmatch.U],
+        [r'usr\\bin', 'usr/bin', False, fnmatch.C | fnmatch.U],
+        [r'usr\\bin', 'usr\\bin', True, fnmatch.C | fnmatch.U],
+
+        # Case and Force Windows: slash conventions
+        ['usr/bin', 'usr/bin', True, fnmatch.C | fnmatch.W],
+        ['usr/bin', 'usr\\bin', True, fnmatch.C | fnmatch.W],
+        [r'usr\\bin', 'usr/bin', True, fnmatch.C | fnmatch.W],
+        [r'usr\\bin', 'usr\\bin', True, fnmatch.C | fnmatch.W],
+
+        # Deprecated: Force Case
         ['abc', 'abc', True, fnmatch.F],
         ['abc', 'AbC', False, fnmatch.F],
         ['AbC', 'abc', False, fnmatch.F],
         ['AbC', 'AbC', True, fnmatch.F],
 
-        # Force case: slash conventions
         ['usr/bin', 'usr/bin', True, fnmatch.F],
         ['usr/bin', 'usr\\bin', False, fnmatch.F],
         [r'usr\\bin', 'usr/bin', False, fnmatch.F],
@@ -79,7 +96,7 @@ class TestFnMatch:
         ['AbC', 'abc', not util.is_case_sensitive(), 0],
         ['AbC', 'AbC', True, 0],
         ['abc', 'AbC', True, fnmatch.W],
-        ['abc', 'AbC', True, fnmatch.W | fnmatch.F],  # Can't force case if forcing Windows
+        ['abc', 'AbC', True, fnmatch.W | fnmatch.F],  # Deprecated: Can't force case if forcing Windows
         ['abc', 'AbC', False, fnmatch.U],
         ['abc', 'AbC', True, fnmatch.U | fnmatch.I],
         ['AbC', 'abc', not util.is_case_sensitive(), fnmatch.W | fnmatch.U],  # Can't force both, just detect system
@@ -245,7 +262,7 @@ class TestFnMatchFilter:
             0
         ],
         [r'te\st[ma]', ['testm', 'test\\3', 'testa'], ['testm', 'testa'], fnmatch.I],
-        [r'te\st[ma]', ['testm', 'test\\3', 'testa'], ['testm', 'testa'], fnmatch.F],
+        [r'te\st[ma]', ['testm', 'test\\3', 'testa'], ['testm', 'testa'], fnmatch.C],
 
         # Issue #24
         ['*.bar', ["goo.cfg", "foo.bar", "foo.bar.cfg", "foo.cfg.bar"], ["foo.bar", "foo.cfg.bar"], 0],
@@ -306,15 +323,13 @@ class TestFnMatchTranslate(unittest.TestCase):
 
         return fnmatch.translate(pattern, flags=flags | fnmatch.SPLIT)
 
-    @mock.patch('wcmatch.util.is_case_sensitive')
-    def test_split_parsing(self, mock__iscase_sensitive):
+    def test_split_parsing(self):
         """Test wildcard parsing."""
-
-        mock__iscase_sensitive.return_value = True
 
         _wcparse._compile.cache_clear()
 
-        flags = self.flags
+        flags = self.flags | fnmatch.FORCEUNIX
+
         p1, p2 = self.split_translate('*test[a-z]?|*test2[a-z]?|!test[!a-z]|!test[!-|a-z]', flags | fnmatch.N)
         if util.PY36:
             self.assertEqual(p1, [r'^(?s:(?=.).*?test[a-z].)$', r'^(?s:(?=.).*?test2[a-z].)$'])
@@ -323,7 +338,7 @@ class TestFnMatchTranslate(unittest.TestCase):
             self.assertEqual(p1, [r'(?s)^(?:(?=.).*?test[a-z].)$', r'(?s)^(?:(?=.).*?test2[a-z].)$'])
             self.assertEqual(p2, [r'(?s)^(?:test[^a-z])$', r'(?s)^(?:test[^\-\|a-z])$'])
 
-        p1, p2 = self.split_translate('test[]][!][][]', flags | fnmatch.F)
+        p1, p2 = self.split_translate('test[]][!][][]', flags | fnmatch.U | fnmatch.C)
         if util.PY36:
             self.assertEqual(p1, [r'^(?s:test[\]][^\][]\[\])$'])
             self.assertEqual(p2, [])
@@ -387,13 +402,13 @@ class TestFnMatchTranslate(unittest.TestCase):
     def test_posix_range(self):
         """Test posix range."""
 
-        p = fnmatch.translate(r'[[:ascii:]-z]', flags=self.flags | fnmatch.F)
+        p = fnmatch.translate(r'[[:ascii:]-z]', flags=self.flags | fnmatch.U | fnmatch.C)
         if util.PY36:
             self.assertEqual(p, (['^(?s:[\x00-\x7f\\-z])$'], []))
         else:
             self.assertEqual(p, (['(?s)^(?:[\x00-\x7f\\-z])$'], []))
 
-        p = fnmatch.translate(r'[a-[:ascii:]-z]', flags=self.flags | fnmatch.F)
+        p = fnmatch.translate(r'[a-[:ascii:]-z]', flags=self.flags | fnmatch.U | fnmatch.C)
         if util.PY36:
             self.assertEqual(p, (['^(?s:[a\\-\x00-\x7f\\-z])$'], []))
         else:
@@ -403,12 +418,12 @@ class TestFnMatchTranslate(unittest.TestCase):
     def test_special_escapes(self, mock__iscase_sensitive):
         """Test wildcard character notations."""
 
-        mock__iscase_sensitive.return_value = True
+        flags = self.flags | fnmatch.U
 
         _wcparse._compile.cache_clear()
 
         p1, p2 = fnmatch.translate(
-            r'test\x70\u0070\U00000070\160\N{LATIN SMALL LETTER P}', flags=self.flags | fnmatch.R
+            r'test\x70\u0070\U00000070\160\N{LATIN SMALL LETTER P}', flags=flags | fnmatch.R
         )
         if util.PY36:
             self.assertEqual(p1, [r'^(?s:testppppp)$'])
@@ -418,7 +433,7 @@ class TestFnMatchTranslate(unittest.TestCase):
             self.assertEqual(p2, [])
 
         p1, p2 = fnmatch.translate(
-            r'test[\x70][\u0070][\U00000070][\160][\N{LATIN SMALL LETTER P}]', flags=self.flags | fnmatch.R
+            r'test[\x70][\u0070][\U00000070][\160][\N{LATIN SMALL LETTER P}]', flags=flags | fnmatch.R
         )
         if util.PY36:
             self.assertEqual(p1, [r'^(?s:test[p][p][p][p][p])$'])
@@ -427,7 +442,7 @@ class TestFnMatchTranslate(unittest.TestCase):
             self.assertEqual(p1, [r'(?s)^(?:test[p][p][p][p][p])$'])
             self.assertEqual(p2, [])
 
-        p1, p2 = fnmatch.translate(r'test\t\m', flags=self.flags | fnmatch.R)
+        p1, p2 = fnmatch.translate(r'test\t\m', flags=flags | fnmatch.R)
         if util.PY36:
             self.assertEqual(p1, [r'^(?s:test\	m)$'])
             self.assertEqual(p2, [])
@@ -435,7 +450,7 @@ class TestFnMatchTranslate(unittest.TestCase):
             self.assertEqual(p1, [r'(?s)^(?:test\	m)$'])
             self.assertEqual(p2, [])
 
-        p1, p2 = fnmatch.translate(r'test[\\]test', flags=self.flags | fnmatch.R)
+        p1, p2 = fnmatch.translate(r'test[\\]test', flags=flags | fnmatch.R)
         if util.PY36:
             self.assertEqual(p1, [r'^(?s:test[\\]test)$'])
             self.assertEqual(p2, [])
@@ -443,7 +458,7 @@ class TestFnMatchTranslate(unittest.TestCase):
             self.assertEqual(p1, [r'(?s)^(?:test[\\]test)$'])
             self.assertEqual(p2, [])
 
-        p1, p2 = fnmatch.translate('test[\\', flags=self.flags)
+        p1, p2 = fnmatch.translate('test[\\', flags=flags)
         if util.PY36:
             self.assertEqual(p1, [r'^(?s:test\[\\)$'])
             self.assertEqual(p2, [])
@@ -451,7 +466,7 @@ class TestFnMatchTranslate(unittest.TestCase):
             self.assertEqual(p1, [r'(?s)^(?:test\[\\)$'])
             self.assertEqual(p2, [])
 
-        p1, p2 = fnmatch.translate(r'test\44test', flags=self.flags | fnmatch.R)
+        p1, p2 = fnmatch.translate(r'test\44test', flags=flags | fnmatch.R)
         if util.PY36:
             self.assertEqual(p1, [r'^(?s:test\$test)$'])
             self.assertEqual(p2, [])
@@ -459,7 +474,7 @@ class TestFnMatchTranslate(unittest.TestCase):
             self.assertEqual(p1, [r'(?s)^(?:test\$test)$'])
             self.assertEqual(p2, [])
 
-        p1, p2 = fnmatch.translate(r'test\44', flags=self.flags | fnmatch.R)
+        p1, p2 = fnmatch.translate(r'test\44', flags=flags | fnmatch.R)
         if util.PY36:
             self.assertEqual(p1, [r'^(?s:test\$)$'])
             self.assertEqual(p2, [])
@@ -467,7 +482,7 @@ class TestFnMatchTranslate(unittest.TestCase):
             self.assertEqual(p1, [r'(?s)^(?:test\$)$'])
             self.assertEqual(p2, [])
 
-        p1, p2 = fnmatch.translate(r'test\400', flags=self.flags | fnmatch.R)
+        p1, p2 = fnmatch.translate(r'test\400', flags=flags | fnmatch.R)
         if util.PY37:
             self.assertEqual(p1, [r'^(?s:testĀ)$'])
             self.assertEqual(p2, [])
@@ -479,13 +494,13 @@ class TestFnMatchTranslate(unittest.TestCase):
             self.assertEqual(p2, [])
 
         with pytest.raises(SyntaxError):
-            fnmatch.translate(r'test\N', flags=self.flags | fnmatch.R)
+            fnmatch.translate(r'test\N', flags=flags | fnmatch.R)
 
         with pytest.raises(SyntaxError):
-            fnmatch.translate(r'test\Nx', flags=self.flags | fnmatch.R)
+            fnmatch.translate(r'test\Nx', flags=flags | fnmatch.R)
 
         with pytest.raises(SyntaxError):
-            fnmatch.translate(r'test\N{', flags=self.flags | fnmatch.R)
+            fnmatch.translate(r'test\N{', flags=flags | fnmatch.R)
 
     def test_default_compile(self):
         """Test default with exclusion."""

--- a/tests/test_glob.py
+++ b/tests/test_glob.py
@@ -1125,3 +1125,18 @@ class TestDeprecated(unittest.TestCase):
             self.assertTrue(len(w) == 1)
             self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
             self.assertTrue(patterns, ['test', 'test'])
+
+    def test_forcecase(self):
+        """Test deprecation of force case flag."""
+
+        with warnings.catch_warnings(record=True) as w:
+            # Cause all warnings to always be triggered.
+            warnings.simplefilter("always")
+
+            glob.glob('*', flags=glob.F)
+            list(glob.iglob('*', flags=glob.F))
+            glob.translate('*', flags=glob.F),
+            glob.globmatch('path', "*", flags=glob.F)
+            glob.globfilter(['path'], "*", flags=glob.F)
+            self.assertEqual(len(w), 5)
+            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))

--- a/tests/test_glob.py
+++ b/tests/test_glob.py
@@ -12,6 +12,7 @@ made difference in implementation.
 import contextlib
 from wcmatch import glob
 from wcmatch import util
+import re
 import types
 import pytest
 import os
@@ -469,6 +470,18 @@ class Testglob(_TestGlob):
             [('a', 'bcd', 'EF')] if util.is_case_sensitive() else [('a', 'bcd', 'EF'), ('a', 'bcd', 'efg')]
         ],
         [('a', 'bcd', '*g'), [('a', 'bcd', 'efg')]],
+
+        # Test case sensitive and insensitive
+        [
+            ('a', 'bcd', 'E*'),
+            [('a', 'bcd', 'EF')],
+            glob.C
+        ],
+        [
+            ('a', 'bcd', 'E*'),
+            [('a', 'bcd', 'EF'), ('a', 'bcd', 'efg')],
+            glob.I
+        ],
 
         # Test glob directory names.
         [('*', 'D'), [('a', 'D')]],
@@ -982,8 +995,45 @@ class TestGlobEscapes(unittest.TestCase):
         check('//*/*/*', r'//*/*/\*')
 
 
+@unittest.skipUnless(sys.platform.startswith('win'), "Windows specific test")
+class TestWindowsDriveCase(unittest.TestCase):
+    """Test Windows drive case."""
+
+    RE_DRIVE = re.compile(r'((?:\\|/){2}[^\\/]+(?:\\|/){1}[^\\/]+|[a-z]:)((?:\\|/){1}|$)', re.I)
+
+    def test_drive_insensitive(self):
+        """Test drive case insensitivity."""
+
+        cwd = os.getcwd()
+        filepath = os.path.join(cwd, 'README.md')
+        self.assertEqual([filepath], glob.glob(filepath.replace('\\', '\\\\')))
+        self.assertEqual(
+            [self.RE_DRIVE.sub(lambda m: m.group(0).upper(), filepath)],
+            glob.glob(filepath.replace('\\', '\\\\').upper())
+        )
+        self.assertEqual(
+            [self.RE_DRIVE.sub(lambda m: m.group(0).lower(), filepath)],
+            glob.glob(filepath.replace('\\', '\\\\').lower())
+        )
+
+    def test_drive_sensitive(self):
+        """Test drive case sensitivity (they'll be insensitive regardless of case flag)."""
+
+        cwd = os.getcwd()
+        filepath = os.path.join(cwd, 'README.md')
+        self.assertEqual([filepath], glob.glob(filepath.replace('\\', '\\\\'), flags=glob.C))
+        self.assertEqual(
+            [self.RE_DRIVE.sub(lambda m: m.group(0).upper(), filepath)],
+            glob.glob(self.RE_DRIVE.sub(lambda m: m.group(0).upper(), filepath).replace('\\', '\\\\'), flags=glob.C)
+        )
+        self.assertEqual(
+            [self.RE_DRIVE.sub(lambda m: m.group(0).lower(), filepath)],
+            glob.glob(self.RE_DRIVE.sub(lambda m: m.group(0).lower(), filepath).replace('\\', '\\\\'), flags=glob.C)
+        )
+
+
 @skip_unless_symlink
-class SymlinkLoopGlobTests(unittest.TestCase):
+class TestSymlinkLoopGlob(unittest.TestCase):
     """Symlink loop test case."""
 
     DEFAULT_FLAGS = glob.BRACE | glob.EXTGLOB | glob.GLOBSTAR | glob.FOLLOW

--- a/tests/test_globmatch.py
+++ b/tests/test_globmatch.py
@@ -541,11 +541,7 @@ class TestGlobFilter:
         ['!(dir)/abc', ['directory/abc', 'folder/abc'], glob.M],
 
         # Slash exclusion
-        GlobFiles(
-            [
-                'test/test', 'test\\/test'
-            ]
-        ),
+        GlobFiles(['test/test', 'test\\/test']),
 
         # Deprecated: Force case
         ['test/test', ['test/test'], glob.F],
@@ -582,6 +578,18 @@ class TestGlobFilter:
         ['test\\/TEST', ['test\\/test'], glob.U | glob.I],
         ['TEST/test', [], glob.U],
         ['test\\/TEST', [], glob.U],
+
+        GlobFiles(['c:/some/path', '//host/share/some/path']),
+
+        # Test Windows drive and UNC host/share case sensitivity
+        ['C:/**', ['c:/some/path'], glob.W],
+        ['//HoSt/ShArE/**', ['//host/share/some/path'], glob.W],
+        ['C:/SoMe/PaTh', ['c:/some/path'], glob.W],
+        ['//HoSt/ShArE/SoMe/PaTh', ['//host/share/some/path'], glob.W],
+        ['C:/**', ['c:/some/path'], glob.W | glob.C],
+        ['//HoSt/ShArE/**', ['//host/share/some/path'], glob.W | glob.C],
+        ['C:/SoMe/PaTh', [], glob.W | glob.C],
+        ['//HoSt/ShArE/SoMe/PaTh', [], glob.W | glob.C],
 
         # Issue #24
         GlobFiles(

--- a/tests/test_globmatch.py
+++ b/tests/test_globmatch.py
@@ -546,12 +546,42 @@ class TestGlobFilter:
                 'test/test', 'test\\/test'
             ]
         ),
+
+        # Deprecated: Force case
         ['test/test', ['test/test'], glob.F],
         ['test\\/test', ['test\\/test'], glob.F],
         ['@(test/test)', [], glob.F],
         [r'@(test\/test)', [], glob.F],
         ['test[/]test', [], glob.F],
         [r'test[\/]test', [], glob.F],
+
+        # Force Unix/Linux
+        ['test/test', ['test/test'], glob.U],
+        ['test\\/test', ['test\\/test'], glob.U],
+        ['@(test/test)', [], glob.U],
+        [r'@(test\/test)', [], glob.U],
+        ['test[/]test', [], glob.U],
+        [r'test[\/]test', [], glob.U],
+
+        # Force Windows
+        ['test/test', ['test/test', 'test\\/test'], glob.W],
+        ['test\\/test', ['test/test', 'test\\/test'], glob.W],
+        ['@(test/test)', [], glob.W],
+        [r'@(test\/test)', [], glob.W],
+        ['test[/]test', [], glob.W],
+        [r'test[\/]test', [], glob.W],
+
+        # Case
+        ['TEST/test', ['test/test', 'test\\/test'], glob.W],
+        ['test\\/TEST', ['test/test', 'test\\/test'], glob.W],
+        ['TEST/test', [], glob.W | glob.C],
+        ['test\\/TEST', [], glob.W | glob.C],
+        ['test/test', ['test/test', 'test\\/test'], glob.W | glob.C],
+        ['test\\/test', ['test/test', 'test\\/test'], glob.W | glob.C],
+        ['TEST/test', ['test/test'], glob.U | glob.I],
+        ['test\\/TEST', ['test\\/test'], glob.U | glob.I],
+        ['TEST/test', [], glob.U],
+        ['test\\/TEST', [], glob.U],
 
         # Issue #24
         GlobFiles(

--- a/tests/test_wcmatch.py
+++ b/tests/test_wcmatch.py
@@ -452,6 +452,54 @@ class TestWcmatch(_TestWcmatch):
             )
         )
 
+    def test_match_insensitive(self):
+        """Test case insensitive."""
+
+        walker = wcmatch.WcMatch(
+            self.tempdir,
+            'A.TXT', None,
+            self.default_flags | wcmatch.RECURSIVE | wcmatch.FILEPATHNAME | wcmatch.IGNORECASE
+        )
+        self.crawl_files(walker)
+        self.assertEqual(
+            sorted(self.files),
+            self.norm_list(
+                ['a.txt']
+            )
+        )
+
+    def test_nomatch_sensitive(self):
+        """Test case sensitive does not match."""
+
+        walker = wcmatch.WcMatch(
+            self.tempdir,
+            'A.TXT', None,
+            self.default_flags | wcmatch.RECURSIVE | wcmatch.FILEPATHNAME | wcmatch.CASE
+        )
+        self.crawl_files(walker)
+        self.assertEqual(
+            sorted(self.files),
+            self.norm_list(
+                []
+            )
+        )
+
+    def test_match_sensitive(self):
+        """Test case sensitive."""
+
+        walker = wcmatch.WcMatch(
+            self.tempdir,
+            'a.txt', None,
+            self.default_flags | wcmatch.RECURSIVE | wcmatch.FILEPATHNAME | wcmatch.CASE
+        )
+        self.crawl_files(walker)
+        self.assertEqual(
+            sorted(self.files),
+            self.norm_list(
+                ['a.txt']
+            )
+        )
+
 
 @skip_unless_symlink
 class TestWcmatchSymlink(_TestWcmatch):

--- a/tests/test_wcmatch.py
+++ b/tests/test_wcmatch.py
@@ -2,6 +2,7 @@
 """Tests for `wcmatch`."""
 import unittest
 import os
+import warnings
 import wcmatch.wcmatch as wcmatch
 import shutil
 
@@ -566,3 +567,18 @@ class TestWcmatchSymlink(_TestWcmatch):
                 ['a.txt', '.hidden/a.txt']
             )
         )
+
+
+class TestDeprecated(unittest.TestCase):
+    """Test deprecated."""
+
+    def test_forcecase(self):
+        """Test deprecation of force case flag."""
+
+        with warnings.catch_warnings(record=True) as w:
+            # Cause all warnings to always be triggered.
+            warnings.simplefilter("always")
+
+            wcmatch.WcMatch('', '*', None, wcmatch.FORCECASE)
+            self.assertEqual(len(w), 1)
+            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))

--- a/wcmatch/__meta__.py
+++ b/wcmatch/__meta__.py
@@ -186,5 +186,5 @@ def parse_version(ver, pre=False):
     return Version(major, minor, micro, release, pre, post, dev)
 
 
-__version_info__ = Version(4, 2, 0, "final")
+__version_info__ = Version(4, 3, 0, "final")
 __version__ = __version_info__._get_canonical()

--- a/wcmatch/_wcparse.py
+++ b/wcmatch/_wcparse.py
@@ -292,6 +292,17 @@ def is_unix_style(flags):
     )
 
 
+def deprecate_flags(flags):
+    """Deprecate flags."""
+
+    if flags & FORCECASE:
+        util.warn_deprecated(
+            'FORCECASE flag has been deprecated.'
+            'It is recommended to use FORCEUNIX to force Linux/Unix behavior on Windows '
+            ' and/or use CASE to force case sensitive to force case sensitivity on Windows file paths.'
+        )
+
+
 def translate(patterns, flags):
     """Translate patterns."""
 

--- a/wcmatch/_wcparse.py
+++ b/wcmatch/_wcparse.py
@@ -180,10 +180,14 @@ _EXCLA_GROUP_CLOSE = r')%s)'
 _NO_ROOT = r'(?!/)'
 _NO_WIN_ROOT = r'(?!(?:[\\/]|[a-zA-Z]:))'
 # Restrict directories
-_NO_NIX_DIR = r'^(?:.*?(?:/\.{1,2}/*|/)|\.{1,2}/*)$'
-_NO_WIN_DIR = r'^(?:.*?(?:[\\/]\.{1,2}/*|[\\/])|\.{1,2}[\\/]*)$'
-_NO_NIX_DIR_BYTES = rb'^(?:.*?(?:/\.{1,2}/*|/)|\.{1,2}/*)$'
-_NO_WIN_DIR_BYTES = rb'^(?:.*?(?:[\\/]\.{1,2}/*|[\\/])|\.{1,2}[\\/]*)$'
+_NO_NIX_DIR = (
+    r'^(?:.*?(?:/\.{1,2}/*|/)|\.{1,2}/*)$',
+    rb'^(?:.*?(?:/\.{1,2}/*|/)|\.{1,2}/*)$'
+)
+_NO_WIN_DIR = (
+    r'^(?:.*?(?:[\\/]\.{1,2}/*|[\\/])|\.{1,2}[\\/]*)$',
+    rb'^(?:.*?(?:[\\/]\.{1,2}/*|[\\/])|\.{1,2}[\\/]*)$'
+)
 
 
 class InvPlaceholder(str):
@@ -311,10 +315,8 @@ def translate(patterns, flags):
 
     if patterns and flags & NODIR:
         unix = is_unix_style(flags)
-        if isinstance(patterns[0], bytes):
-            exclude = _NO_NIX_DIR_BYTES if unix else _NO_WIN_DIR_BYTES
-        else:
-            exclude = _NO_NIX_DIR if unix else _NO_WIN_DIR
+        index = BYTES if isinstance(patterns[0], bytes) else UNICODE
+        exclude = _NO_NIX_DIR[index] if unix else _NO_WIN_DIR[index]
         negative.append(exclude)
 
     return positive, negative

--- a/wcmatch/fnmatch.py
+++ b/wcmatch/fnmatch.py
@@ -24,13 +24,14 @@ from . import util
 from . import _wcparse
 
 __all__ = (
-    "EXTMATCH", "FORCECASE", "IGNORECASE", "RAWCHARS",
+    "CASE", "EXTMATCH", "FORCECASE", "IGNORECASE", "RAWCHARS",
     "NEGATE", "MINUSNEGATE", "DOTMATCH", "BRACE", "SPLIT",
     "NEGATEALL", "FORCEWIN", "FORCEUNIX",
-    "F", "I", "R", "N", "M", "D", "E", "S", "B", "A", "W", "U",
+    "C", "F", "I", "R", "N", "M", "D", "E", "S", "B", "A", "W", "U",
     "translate", "fnmatch", "filter", "fnsplit"
 )
 
+C = CASE = _wcparse.CASE
 F = FORCECASE = _wcparse.FORCECASE
 I = IGNORECASE = _wcparse.IGNORECASE
 R = RAWCHARS = _wcparse.RAWCHARS
@@ -45,6 +46,7 @@ W = FORCEWIN = _wcparse.FORCEWIN
 U = FORCEUNIX = _wcparse.FORCEUNIX
 
 FLAG_MASK = (
+    CASE |
     FORCECASE |
     IGNORECASE |
     RAWCHARS |
@@ -70,7 +72,6 @@ def _flag_transform(flags):
     # Force ignore case if Windows
     if flags & _wcparse.FORCEWIN and flags & _wcparse.FORCECASE:
         flags ^= _wcparse.FORCECASE
-        flags |= _wcparse.IGNORECASE
 
     return (flags & FLAG_MASK)
 

--- a/wcmatch/fnmatch.py
+++ b/wcmatch/fnmatch.py
@@ -65,6 +65,8 @@ FLAG_MASK = (
 def _flag_transform(flags):
     """Transform flags to glob defaults."""
 
+    _wcparse.deprecate_flags(flags)
+
     # Enabling both cancels out
     if flags & _wcparse.FORCEUNIX and flags & _wcparse.FORCEWIN:
         flags ^= _wcparse.FORCEWIN | _wcparse.FORCEUNIX

--- a/wcmatch/glob.py
+++ b/wcmatch/glob.py
@@ -28,10 +28,10 @@ from . import _wcparse
 from . import util
 
 __all__ = (
-    "FORCECASE", "IGNORECASE", "RAWCHARS", "DOTGLOB", "DOTMATCH",
+    "CASE", "FORCECASE", "IGNORECASE", "RAWCHARS", "DOTGLOB", "DOTMATCH",
     "EXTGLOB", "EXTMATCH", "GLOBSTAR", "NEGATE", "MINUSNEGATE", "BRACE",
     "REALPATH", "FOLLOW", "MATCHBASE", "MARK", "NEGATEALL", "NODIR", "FORCEWIN", "FORCEUNIX",
-    "F", "I", "R", "D", "E", "G", "N", "M", "B", "P", "L", "S", "X", 'K', "O", "A", "W", "U",
+    "C", "F", "I", "R", "D", "E", "G", "N", "M", "B", "P", "L", "S", "X", 'K', "O", "A", "W", "U",
     "iglob", "glob", "globsplit", "globmatch", "globfilter", "escape"
 )
 
@@ -40,6 +40,7 @@ __all__ = (
 WIN = sys.platform.startswith('win')
 NO_SCANDIR_WORKAROUND = util.PY36
 
+C = CASE = _wcparse.CASE
 F = FORCECASE = _wcparse.FORCECASE
 I = IGNORECASE = _wcparse.IGNORECASE
 R = RAWCHARS = _wcparse.RAWCHARS
@@ -61,6 +62,7 @@ U = FORCEUNIX = _wcparse.FORCEUNIX
 K = MARK = 0x100000
 
 FLAG_MASK = (
+    CASE |
     FORCECASE |
     IGNORECASE |
     RAWCHARS |

--- a/wcmatch/glob.py
+++ b/wcmatch/glob.py
@@ -86,6 +86,8 @@ FLAG_MASK = (
 def _flag_transform(flags):
     """Transform flags to glob defaults."""
 
+    _wcparse.deprecate_flags(flags)
+
     # Enabling both cancels out
     if flags & _wcparse.FORCEUNIX and flags & _wcparse.FORCEWIN:
         flags ^= _wcparse.FORCEWIN | _wcparse.FORCEUNIX

--- a/wcmatch/wcmatch.py
+++ b/wcmatch/wcmatch.py
@@ -104,6 +104,8 @@ class WcMatch(object):
     def _parse_flags(self, flags):
         """Parse flags."""
 
+        _wcparse.deprecate_flags(flags)
+
         self.flags = flags & FLAG_MASK
         self.flags |= _wcparse.NEGATE | _wcparse.DOTMATCH | _wcparse.NEGATEALL
         self.follow_links = bool(self.flags & SYMLINKS)

--- a/wcmatch/wcmatch.py
+++ b/wcmatch/wcmatch.py
@@ -26,13 +26,14 @@ from . import _wcparse
 from . import util
 
 __all__ = (
-    "FORCECASE", "IGNORECASE", "RAWCHARS", "FILEPATHNAME", "DIRPATHNAME",
+    "CASE", "FORCECASE", "IGNORECASE", "RAWCHARS", "FILEPATHNAME", "DIRPATHNAME",
     "EXTMATCH", "GLOBSTAR", "BRACE", "MINUSNEGATE", "SYMLINKS", "HIDDEN", "RECURSIVE",
     "MATCHBASE",
-    "F", "I", "R", "P", "E", "G", "M", "DP", "FP", "SL", "HD", "RV", "X", "B",
+    "C", "F", "I", "R", "P", "E", "G", "M", "DP", "FP", "SL", "HD", "RV", "X", "B",
     "WcMatch"
 )
 
+C = CASE = _wcparse.CASE
 F = FORCECASE = _wcparse.FORCECASE
 I = IGNORECASE = _wcparse.IGNORECASE
 R = RAWCHARS = _wcparse.RAWCHARS
@@ -53,6 +54,7 @@ RV = RECURSIVE = 0x1000000
 P = PATHNAME = DIRPATHNAME | FILEPATHNAME
 
 FLAG_MASK = (
+    CASE |
     FORCECASE |
     IGNORECASE |
     RAWCHARS |


### PR DESCRIPTION
This implements case sensitive matching and globbing in Windows. As Windows can enable case sensitivity on folders etc., or sometimes access shares that are case sensitive, it makes sense to expose case sensitive matching and globbing on Windows.

Despite the fact that folders can be case sensitive, drives still aren't, and it makes no sense to enforce that behavior on the drive letter portion of a path. In addition to that, UNC `\\host\share` portions are usually treated insensitively. While it may be possible the host name is sensitive, there is no real way to quickly and easily get that true case at this time, so UNC host/share portion will be treated as a drive and be insensitive as well while the tail portion will be sensitive.

Now that we have explicit flags for forcing Linux/Unix style matching on Windows and Windows style path matching on Linux/Unix (via `FORCEUNIX` and `FORCELINUX` respectively), and `CASE` which works on all systems without forcing an OS behavior, `FORCECASE` no longer makes sense. Instead of changing its behavior, we will defer to `CASE` moving forward and deprecate `FORCECASE`.
