### PR TITLE
Fix regression with literal start pattern and multiple patterns in glob

### DIFF
--- a/docs/src/markdown/changelog.md
+++ b/docs/src/markdown/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 4.3.1
+
+- **FIX**: Regression for root level literal matches in `glob`.
+- **FIX**: Bug where `glob` would mistakenly abort if a pattern started with a literal file or directory and could not match a file or directory. This caused subsequent patterns in the chain to not get evaluated.
+
 ## 4.3.0
 
 - **NEW**: Add `CASE` flag which allows for case sensitive paths on Linux, macOS, and Windows. Windows drive letters and UNC `//host-name/share-name/` portion are still treated insensitively, but all directories will be treated with case sensitivity.

--- a/tests/test_glob.py
+++ b/tests/test_glob.py
@@ -1099,8 +1099,8 @@ class TestSymlinkLoopGlob(unittest.TestCase):
                 depth += 1
 
 
-class TestGlobRoot(unittest.TestCase):
-    """Test `glob` at root of mount."""
+class TestGlobPaths(unittest.TestCase):
+    """Test `glob` paths."""
 
     def test_root(self):
         """Test that `glob` translates the root properly."""
@@ -1109,6 +1109,14 @@ class TestGlobRoot(unittest.TestCase):
         # On Linux/Unix, this should translate to the root.
         # Basically, we should not return an empty set.
         self.assertTrue(len(glob.glob('/*')) > 0)
+
+    def test_start(self):
+        """Test that starting directory/files are handled properly."""
+
+        self.assertEqual(
+            sorted(['docs', 'wcmatch', 'readme.md']),
+            sorted([each.lower() for each in glob.glob(['BAD', 'docs', 'WCMATCH', 'readme.MD'], flags=glob.I)])
+        )
 
 
 class TestDeprecated(unittest.TestCase):

--- a/wcmatch/__meta__.py
+++ b/wcmatch/__meta__.py
@@ -186,5 +186,5 @@ def parse_version(ver, pre=False):
     return Version(major, minor, micro, release, pre, post, dev)
 
 
-__version_info__ = Version(4, 3, 0, "final")
+__version_info__ = Version(4, 3, 1, "final")
 __version__ = __version_info__._get_canonical()

--- a/wcmatch/glob.py
+++ b/wcmatch/glob.py
@@ -373,7 +373,7 @@ class Glob(object):
                 else:
                     yield path, is_dir
 
-    def _get_starting_paths(self, curdir):
+    def _get_starting_paths(self, curdir, dir_only):
         """
         Get the starting location.
 
@@ -391,7 +391,9 @@ class Glob(object):
             dirname = os.path.dirname(fullpath)
             if basename:
                 matcher = self._get_matcher(basename)
-                results = [(os.path.basename(name), is_dir) for name, is_dir in self._glob_dir(dirname, matcher, self)]
+                results = [
+                    (os.path.basename(name), is_dir) for name, is_dir in self._glob_dir(dirname, matcher, dir_only)
+                ]
 
         return results
 
@@ -422,18 +424,14 @@ class Glob(object):
 
                     # Abort if we cannot find the drive, or if current directory is empty
                     if not curdir or (this.is_drive and not os.path.lexists(curdir)):
-                        return
+                        continue
 
                     # Make sure case matches, but running case insensitive
                     # on a case sensitive file system may return more than
                     # one starting location.
-                    results = [(curdir, True)] if this.is_drive else self._get_starting_paths(curdir)
+                    results = [(curdir, True)] if this.is_drive else self._get_starting_paths(curdir, dir_only)
                     if not results:
-                        if not dir_only:
-                            # There is no directory with this name,
-                            # but we have a file and no directory restriction
-                            yield self.format_path(curdir, False, dir_only)
-                        return
+                        continue
 
                     if this.dir_only:
                         # Glob these directories if they exists


### PR DESCRIPTION
- Regression for root level literal matches in `glob`.
- Bug where `glob` would mistakenly abort if a pattern started with a
literal file or directory and could not match a file or directory.
This caused subsequent patterns in the chain to not get evaluated.