### PR TITLE
Avoid risk of leaking file descriptors

### DIFF
--- a/docs/src/markdown/changelog.md
+++ b/docs/src/markdown/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 5.0.1
+
+- **FIX**: In `glob`, avoid the risk of leaking file descriptors by acquiring all file/folder names under a directory in
+  one batch.
+
 ## 5.0.0
 
 - **NEW**: Add `wcmatch.pathlib` which contains `pathlib` variants that uses `wcmatch.glob` instead of the default

--- a/docs/src/markdown/pathlib.md
+++ b/docs/src/markdown/pathlib.md
@@ -388,11 +388,9 @@ into account things like sequences (`[]`) and extended patterns (`*(...)`) and w
 escape the delimiters if needed: `\|`.
 
 ```pycon3
->>> from wcmatch import glob
->>> glob.globmatch('test.txt', r'*.txt|*.py', flags=fnmatch.SPLIT)
-True
->>> glob.globmatch('test.py', r'*.txt|*.py', flags=fnmatch.SPLIT)
-True
+>>> from wcmatch import pathlib
+>>> list(pathlib.Path('.').glob('README.md|LICENSE.md', flags=pathlib.SPLIT))
+[WindowsPath('README.md'), WindowsPath('LICENSE.md')]
 ```
 
 #### `pathlib.MATCHBASE, pathlib.X` {: #pathlibmatchbase}
@@ -402,9 +400,9 @@ the tree with a matching basename, or in the case of [`match`](#purepathmatch) a
 path whose basename matches.
 
 ```pycon3
->>> from wcmatch import glob
->>> glob.glob('*.txt', flags=glob.MATCHBASE)
-['docs/src/dictionary/en-custom.txt', 'docs/src/markdown/_snippets/abbr.txt', 'docs/src/markdown/_snippets/links.txt', 'docs/src/markdown/_snippets/posix.txt', 'docs/src/markdown/_snippets/refs.txt', 'requirements/docs.txt', 'requirements/lint.txt', 'requirements/setup.txt', 'requirements/test.txt', 'requirements/tools.txt']
+>>> from wcmatch import pathlib
+>>> list(pathlib.Path('.').glob('*.txt', flags=pathlib.MATCHBASE))
+[WindowsPath('docs/src/dictionary/en-custom.txt'), WindowsPath('docs/src/markdown/_snippets/abbr.txt'), WindowsPath('docs/src/markdown/_snippets/links.txt'), WindowsPath('docs/src/markdown/_snippets/posix.txt'), WindowsPath('docs/src/markdown/_snippets/refs.txt'), WindowsPath('requirements/docs.txt'), WindowsPath('requirements/lint.txt'), WindowsPath('requirements/setup.txt'), WindowsPath('requirements/test.txt'), WindowsPath('requirements/tools.txt'), WindowsPath('site/_snippets/abbr.txt'), WindowsPath('site/_snippets/links.txt'), WindowsPath('site/_snippets/posix.txt'), WindowsPath('site/_snippets/refs.txt')]  
 ```
 
 #### `pathlib.NODIR, pathlib.O` {: #pathlibnodir}
@@ -413,11 +411,11 @@ path whose basename matches.
 not be possible as those classes do not access the file system, nor will they retain trailing slashes.
 
 ```pycon3
->>> from wcmatch import glob
->>> glob.glob('*', flags=glob.NODIR)
-['appveyor.yml', 'LICENSE.md', 'MANIFEST.in', 'mkdocs.yml', 'README.md', 'setup.cfg', 'setup.py', 'spell.log', 'tox.ini']
->>> glob.glob('*')
-['appveyor.yml', 'docs', 'LICENSE.md', 'MANIFEST.in', 'mkdocs.yml', 'README.md', 'requirements', 'setup.cfg', 'setup.py', 'spell.log', 'tests', 'tools', 'tox.ini', 'wcmatch']
+>>> from wcmatch import pathlib
+>>> list(pathlib.Path('.').glob('*', flags=pathlib.NODIR))
+[WindowsPath('appveyor.yml'), WindowsPath('LICENSE.md'), WindowsPath('MANIFEST.in'), WindowsPath('mkdocs.yml'), WindowsPath('README.md'), WindowsPath('setup.cfg'), WindowsPath('setup.py'), WindowsPath('tox.ini')] 
+>>> list(pathlib.Path('.').glob('*'))
+[WindowsPath('appveyor.yml'), WindowsPath('docs'), WindowsPath('LICENSE.md'), WindowsPath('MANIFEST.in'), WindowsPath('mkdocs.yml'), WindowsPath('README.md'), WindowsPath('requirements'), WindowsPath('setup.cfg'), WindowsPath('setup.py'), WindowsPath('site'), WindowsPath('tests'), WindowsPath('tox.ini'), WindowsPath('wcmatch')]
 ```
 
 --8<--

--- a/docs/src/markdown/wcmatch.md
+++ b/docs/src/markdown/wcmatch.md
@@ -11,7 +11,8 @@ from wcmatch import wcmatch
 select a base path, define one or more file patterns they wanted to search for, and provide folders to exclude if
 needed. It needed to be aware of hidden files on different systems, not just ignoring files that start with `.`. It also
 needed to be extendable so we could further filter returned files by size, creation date, or whatever else was decided.
-While `glob` is a fantastic file and folder search tool, it just didn't make sense for such a user interface.
+While [`glob`](./glob.md) is a fantastic file and folder search tool, it just didn't make sense for such a user
+interface.
 
 ## `wcmatch.WcMatch`
 

--- a/wcmatch/__meta__.py
+++ b/wcmatch/__meta__.py
@@ -186,5 +186,5 @@ def parse_version(ver, pre=False):
     return Version(major, minor, micro, release, pre, post, dev)
 
 
-__version_info__ = Version(5, 0, 0, "final")
+__version_info__ = Version(5, 0, 1, ".dev")
 __version__ = __version_info__._get_canonical()

--- a/wcmatch/wcmatch.py
+++ b/wcmatch/wcmatch.py
@@ -252,7 +252,7 @@ class WcMatch(object):
                     break
 
             # Search files if they were found
-            if len(files):
+            if files:
                 # Only search files that are in the include rules
                 for name in files:
                     try:


### PR DESCRIPTION
We need to grab all the files and folder names under a folder in one
batch to avoid leaking file descriptors in glob.