### PR TITLE
Fix pathlib handling of negate patterns

### DIFF
--- a/docs/src/markdown/changelog.md
+++ b/docs/src/markdown/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 5.0.3
+
+- **FIX**: Rework `glob` relative path handling so internally it is indistinguishable from when it is given no relative
+  path and uses the current working directory. This fixes an issue where `pathlib` couldn't handle negate patterns
+  properly (`!negate`).
+
 ## 5.0.2
 
 - **FIX**: Fix case where a `GLOBSTAR` pattern, followed by a slash, was not disabling `MATCHBASE`.

--- a/tests/test_pathlib.py
+++ b/tests/test_pathlib.py
@@ -55,6 +55,16 @@ class TestGlob(unittest.TestCase):
         self.assertTrue(len(results))
         self.assertTrue(all([file.suffix == '.md' for file in results]))
 
+    def test_relative_exclude(self):
+        """Test relative path exclude."""
+
+        abspath = os.path.abspath('.')
+        p = pathlib.Path(abspath)
+        with change_cwd(os.path.dirname(abspath)):
+            results = list(p.glob('docs/**/*.md|!**/index.md', flags=pathlib.GLOBSTAR | pathlib.NEGATE | pathlib.SPLIT))
+        self.assertTrue(len(results))
+        self.assertTrue(all([file.name != 'index.md' for file in results]))
+
     def test_glob(self):
         """Test globbing function."""
 

--- a/wcmatch/__meta__.py
+++ b/wcmatch/__meta__.py
@@ -186,5 +186,5 @@ def parse_version(ver, pre=False):
     return Version(major, minor, micro, release, pre, post, dev)
 
 
-__version_info__ = Version(5, 0, 2, "final")
+__version_info__ = Version(5, 0, 3, "final")
 __version__ = __version_info__._get_canonical()

--- a/wcmatch/glob.py
+++ b/wcmatch/glob.py
@@ -268,7 +268,7 @@ class Glob(object):
                     # Quicker to just test this way than to run through `fnmatch`.
                     if deep and self._is_hidden(f):
                         continue
-                    path = os.path.join(curdir, f)
+                    path = os.path.join(scandir, f)
                     try:
                         is_dir = os.path.isdir(path)
                     except OSError:  # pragma: no cover

--- a/wcmatch/pathlib.py
+++ b/wcmatch/pathlib.py
@@ -77,7 +77,7 @@ class Path(pathlib.Path):
         if self.is_dir():
             flags = self._translate_flags(flags | _wcparse._NOABSOLUTE)
             for filename in glob.Glob(util.to_tuple(patterns), flags, curdir=str(self)).glob():
-                yield self._from_parts([filename])
+                yield self.joinpath(filename)
 
     def rglob(self, patterns, *, flags=0):
         """


### PR DESCRIPTION
This should fix all pathlib issues related to relative path handling.
Glob now handles any base path just like it would for the CWD.

Negate patterns were broken in pathlib due to the fact that there paths
were compared to the exclusion pattern not as relative paths to the
base, but as paths including the base. This keeps the whole glob
pipeline dealing with paths relative the base only. The base will never
come into play except at key points where the file system must be
accessed: scandir, lexists, etc.

Glob will now return the paths relative to the main path, and pathlib
will simply create a new pathlib object by joining the relative segment.