### PR TITLE
Fix internal comment on glob pattern breakdown

### DIFF
--- a/wcmatch/_wcparse.py
+++ b/wcmatch/_wcparse.py
@@ -374,8 +374,8 @@ class WcPathSplit(object):
     """
     Split glob pattern on "magic" file and directories.
 
-    Glob pattern return a list of pieces. Each piece will either
-    be consecutive literal file parts or individual glob parts.
+    Glob pattern return a list of patterns broken down at the directory
+    boundary. Each piece will either be a literal file part or a magic part.
     Each part will will contain info regarding whether they are
     a directory pattern or a file pattern and whether the part
     is "magic", etc.: `["pattern", is_magic, is_globstar, dir_only, is_drive]`.
@@ -388,7 +388,8 @@ class WcPathSplit(object):
         ```
         [
             ["**", True, True, False, False],
-            ["this/is_literal/", False, False, True, False],
+            ["this", False, False, True, False],
+            ["is_literal", False, False, True, False],
             ["*magic?", True, False, True, False],
             ["@(magic|part)", True, False, False, False]
         ]


### PR DESCRIPTION
Once upon a time, the internal glob pattern was broken down into literal
parts containing consecutive literal file parts, and then magic parts.

Now there are no consecutive literals contained in a single part, but
each literal directory/file are contained within their own part. Update
docstring to reflect that.