### PR TITLE
Process BRACE before SPLIT and refactor SPLIT some

### DIFF
--- a/docs/src/dictionary/en-custom.txt
+++ b/docs/src/dictionary/en-custom.txt
@@ -65,6 +65,7 @@ subdirectories
 sublicense
 symlink
 symlinks
+syntaxes
 tuple
 un
 unclosed

--- a/docs/src/dictionary/en-custom.txt
+++ b/docs/src/dictionary/en-custom.txt
@@ -2,6 +2,7 @@ API
 Accessors
 Backport
 Changelog
+EXTMATCH
 EmojiOne
 Fnmatch
 GitHub
@@ -36,6 +37,7 @@ filename
 filenames
 filepath
 filesystem
+glob
 globbing
 initializer
 lookahead
@@ -50,6 +52,7 @@ posix
 pre
 prepend
 preprocessing
+preprocessors
 prerelease
 prereleases
 recursing

--- a/docs/src/markdown/changelog.md
+++ b/docs/src/markdown/changelog.md
@@ -1,18 +1,21 @@
 # Changelog
 
-## 5.2.0
+## 6.0.0
 
 - **NEW**: Tilde user expansion support via the new `GLOBTILDE` flag.
+- **NEW**: `glob` by default now returns only unique results, regardless of whether multiple patterns that match the
+  same file were provided, or even when `BRACE` or `SPLIT` expansion produces new patterns that match the same file.
+- **NEW**: A new flag called `NOUNIQUE` has been added that makes `glob` act like Bash, which will return the same file
+  multiple times if multiple patterns match it, whether provided directly or due to the result of `BRACE` or `SPLIT`
+  expansion.
+- **FIX**: Matching functions that receive multiple patterns, or that receive a single pattern that expands to multiple,
+  will filter out duplicate patterns in order avoid redundant matching. While the `WcMatch` class crawls the file
+  system, it utilizes the aforementioned matching functions in it's operation, and indirectly takes advantage of this.
+  `glob` (and related functions: `rglob`, `iglob`, etc.) will also filter redundant patterns except when `NOUNIQUE` is
+  enabled.
 - **FIX**: `RAWCHARS` was inconsistently applied at different times depending on what was calling it. It is now applied
   first followed by `BRACE`, `SPLIT`, and finally `GLOBTILDE`.
-- **FIX**: Edge cases related to processing `SPLIT` before `BRACE`. `BRACE` is now processed before `SPLIT`.
-- **FIX**: Matching functions (`globmatch`, `fnmatch`, `translate`, `filter`, etc.), when expanding patterns using
-  `BRACE` and `SPLIT`, will filter out duplicate patterns to ensure faster matching. File crawling functions such as
-  `glob`, `iglob`, `pathlib`'s `glob` and `rglob` do not filter out duplicates as they are meant to return exactly what
-  the user specifies. It is recommended that users pick one syntax or the other when globbing a file system as using
-  `BRACE` and `SPLIT` syntax together can a lot of duplicate patterns.
-- **FIX**: `WcMatch` class will filter out duplicate patterns when using `SPLIT` and/or `BRACE` to expand patterns as it
-  crawls a file system in one pass and uses file matching functions instead of globbing functions.
+- **FIX**: `BRACE` is now processed before `SPLIT` in order to fix a number of edge cases.
 
 ## 5.1.0
 

--- a/docs/src/markdown/changelog.md
+++ b/docs/src/markdown/changelog.md
@@ -6,6 +6,13 @@
 - **FIX**: `RAWCHARS` was inconsistently applied at different times depending on what was calling it. It is now applied
   first followed by `BRACE`, `SPLIT`, and finally `GLOBTILDE`.
 - **FIX**: Edge cases related to processing `SPLIT` before `BRACE`. `BRACE` is now processed before `SPLIT`.
+- **FIX**: Matching functions (`globmatch`, `fnmatch`, `translate`, `filter`, etc.), when expanding patterns using
+  `BRACE` and `SPLIT`, will filter out duplicate patterns to ensure faster matching. File crawling functions such as
+  `glob`, `iglob`, `pathlib`'s `glob` and `rglob` do not filter out duplicates as they are meant to return exactly what
+  the user specifies. It is recommended that users pick one syntax or the other when globbing a file system as using
+  `BRACE` and `SPLIT` syntax together can a lot of duplicate patterns.
+- **FIX**: `WcMatch` class will filter out duplicate patterns when using `SPLIT` and/or `BRACE` to expand patterns as it
+  crawls a file system in one pass and uses file matching functions instead of globbing functions.
 
 ## 5.1.0
 

--- a/docs/src/markdown/changelog.md
+++ b/docs/src/markdown/changelog.md
@@ -4,7 +4,8 @@
 
 - **NEW**: Tilde user expansion support via the new `GLOBTILDE` flag.
 - **FIX**: `RAWCHARS` was inconsistently applied at different times depending on what was calling it. It is now applied
-  first followed by `SPLIT`, `BRACES`, and finally `GLOBTILDE`.
+  first followed by `BRACE`, `SPLIT`, and finally `GLOBTILDE`.
+- **FIX**: Edge cases related to processing `SPLIT` before `BRACE`. `BRACE` is now processed before `SPLIT`.
 
 ## 5.1.0
 

--- a/docs/src/markdown/changelog.md
+++ b/docs/src/markdown/changelog.md
@@ -9,7 +9,7 @@
   multiple times if multiple patterns match it, whether provided directly or due to the result of `BRACE` or `SPLIT`
   expansion.
 - **NEW**: Limit number of patterns that can be processed (expanded and otherwise) to 1000. Allow user to change this
-  value via `pattern_limit` option in API functions.
+  value via `limit` option in API functions.
 - **FIX**: Matching functions that receive multiple patterns, or that receive a single pattern that expands to multiple,
   will filter out duplicate patterns in order avoid redundant matching. While the `WcMatch` class crawls the file
   system, it utilizes the aforementioned matching functions in it's operation, and indirectly takes advantage of this.

--- a/docs/src/markdown/changelog.md
+++ b/docs/src/markdown/changelog.md
@@ -8,6 +8,8 @@
 - **NEW**: A new flag called `NOUNIQUE` has been added that makes `glob` act like Bash, which will return the same file
   multiple times if multiple patterns match it, whether provided directly or due to the result of `BRACE` or `SPLIT`
   expansion.
+- **NEW**: Limit number of patterns that can be processed (expanded and otherwise) to 1000. Allow user to change this
+  value via `pattern_limit` option in API functions.
 - **FIX**: Matching functions that receive multiple patterns, or that receive a single pattern that expands to multiple,
   will filter out duplicate patterns in order avoid redundant matching. While the `WcMatch` class crawls the file
   system, it utilizes the aforementioned matching functions in it's operation, and indirectly takes advantage of this.

--- a/docs/src/markdown/fnmatch.md
+++ b/docs/src/markdown/fnmatch.md
@@ -194,6 +194,10 @@ other character. Dots will not be matched in `[]`, `*`, or `?`.
 `EXTMATCH` enables extended pattern matching. This includes special pattern lists such as `+(...)`, `*(...)`, `?(...)`,
 etc. See the [syntax overview](#syntax) for more information.
 
+!!! tip "EXTMATCH and NEGATE"
+    When using `EXTMATCH` and [`NEGATE`](#fnmatchnegate) together, it is recommended to also use
+    [`MINUSNEGATE`](#fnmatchminusnegate) to avoid conflicts in regards to the `!` meta character.
+
 #### `fnmatch.BRACE, fnmatch.B` {: #fnmatchbrace}
 
 `BRACE` enables Bash style brace expansion: `a{b,{c,d}}` --> `ab ac ad`. Brace expansion is applied before anything
@@ -202,9 +206,10 @@ else. When applied, a pattern will be expanded into multiple patterns. Each patt
 For simple patterns, it may make more sense to use [`EXTMATCH`](#fnmatchextmatch) which will only generate a single
 pattern: `@(ab|ac|ad)`.
 
-Be careful with patterns such as `{1..100}` which would generate one hundred patterns that will all get individually
-parsed. Sometimes you really need such a pattern, but be mindful that it will be slower as you generate larger sets of
-patterns.
+!!! warning "Using BRACE responsibly"
+    Be careful with patterns such as `{1..100}` which would generate one hundred patterns that will all get individually
+    parsed. Sometimes you really need such a pattern, but be mindful that it will be slower as you generate larger sets
+    of patterns.
 
 #### `fnmatch.SPLIT, fnmatch.S` {: #fnmatchsplit}
 
@@ -220,6 +225,8 @@ True
 >>> fnmatch.fnmatch('test.py', r'*.txt|*.py', flags=fnmatch.SPLIT)
 True
 ```
+
+`SPLIT` syntax also pairs really well with [`EXTGLOB`](#fnmatchextmatch).
 
 #### `fnmatch.FORCEWIN, fnmatch.W` {: #fnmatchforcewin}
 

--- a/docs/src/markdown/fnmatch.md
+++ b/docs/src/markdown/fnmatch.md
@@ -11,7 +11,7 @@ It is mainly used for matching filenames with glob patterns. For path names, Wil
 [`globmatch`](./glob.md#globglobmatch) is a more appropriate choice. Not all of the features listed below are enabled by
 default. See [flags](#flags) for more information.
 
-!!! tip
+!!! tip "Backslashes"
     When using backslashes, it is helpful to use raw strings. In a raw string, a single backslash is used to escape a
     character `#!py3 r'\?'`.  If you want to represent a literal backslash, you must use two: `#!py3 r'some\\path'`.
 
@@ -39,16 +39,26 @@ Pattern           | Meaning
 
 --8<-- "posix.txt"
 
+## Multi-Pattern Limits
+
+Many of the API functions allow passing in multiple patterns or using either [`BRACE`](#fnmatchbrace) or
+[`SPLIT`](#fnmatchsplit) to expand a pattern in to more patterns. The number of allowed patterns is limited `1000`, but
+you can raise or lower this limit via the keyword option `limit`. If you set `limit` to `0`, there will
+be no limit.
+
+!!! new "New 6.0"
+    The imposed pattern limit and corresponding `limit` option was introduced in 6.0.
+
 ## API
 
 #### `fnmatch.fnmatch`
 
 ```py3
-def fnmatch(filename, patterns, *, flags=0)
+def fnmatch(filename, patterns, *, flags=0, limit=1000)
 ```
 
-`fnmatch` takes a file name, a pattern (or list of patterns), and flags.  It will return a boolean indicating whether
-the file name was matched by the pattern(s).
+`fnmatch` takes a file name, a pattern (or list of patterns), and flags.  It also allows configuring the [max pattern
+limit](#multi-pattern-limits). It will return a boolean indicating whether the file name was matched by the pattern(s).
 
 ```pycon3
 >>> from wcmatch import fnmatch
@@ -94,15 +104,18 @@ False
 True
 ```
 
+!!! new "New 6.0"
+    `limit` was added in 6.0.
+
 #### `fnmatch.filter`
 
 ```py3
-def filter(filenames, patterns, *, flags=0):
+def filter(filenames, patterns, *, flags=0, limit=1000):
 ```
 
-`filter` takes a list of filenames, a pattern (or list of patterns), and flags. It returns a list of all files that
-matched the pattern(s). The same logic used for [`fnmatch`](#fnmatchfnmatch) is used for `filter`, albeit more efficient
-for processing multiple files.
+`filter` takes a list of filenames, a pattern (or list of patterns), and flags. It also allows configuring the [max 
+pattern limit](#multi-pattern-limits). It returns a list of all files that matched the pattern(s). The same logic used for
+[`fnmatch`](#fnmatchfnmatch) is used for `filter`, albeit more efficient for processing multiple files.
 
 ```pycon3
 >>> from wcmatch import fnmatch
@@ -110,16 +123,19 @@ for processing multiple files.
 ['a.txt', 'b.txt']
 ```
 
+!!! new "New 6.0"
+    `limit` was added in 6.0.
+
 #### `fnmatch.translate`
 
 ```py3
-def translate(patterns, *, flags=0):
+def translate(patterns, *, flags=0, limit=1000):
 ```
 
-`translate` takes a file pattern (or list of patterns) and returns two lists: one for inclusion patterns and one for
-exclusion patterns. The lists contain the regular expressions used for matching the given patterns. It should be noted
-that a file is considered matched if it matches at least one inclusion pattern and matches **none** of the exclusion
-patterns.
+`translate` takes a file pattern (or list of patterns) and flags. It also allows configuring the [max pattern
+limit](#multi-pattern-limits). It returns two lists: one for inclusion patterns and one for exclusion patterns. The
+lists contain the regular expressions used for matching the given patterns. It should be noted that a file is considered
+matched if it matches at least one inclusion pattern and matches **none** of the exclusion patterns.
 
 ```pycon3
 >>> from wcmatch import translate
@@ -132,6 +148,9 @@ patterns.
 !!! warning "Changed 4.0"
     Translate now outputs exclusion patterns so that if they match, the file is excluded. This is opposite logic to how
     it used to be, but is more efficient.
+
+!!! new "New 6.0"
+    `limit` was added in 6.0.
 
 ## Flags
 

--- a/docs/src/markdown/glob.md
+++ b/docs/src/markdown/glob.md
@@ -647,7 +647,7 @@ matching with redundant patterns and excessive crawls through the file system. A
 been fed into [`glob`](#globglob) may match the same file, the results are also filtered as to not return duplicates.
 
 `NOUNIQUE` disables all of the aforementioned "unique" optimizations, but only for [`glob`](#globglob) and
-[`iglob`](#globiglob). Functions like [`globmatch`](#globglobmatch) andn [`globfilter`](#globglobfilter) would get no
+[`iglob`](#globiglob). Functions like [`globmatch`](#globglobmatch) and [`globfilter`](#globglobfilter) would get no
 benefit from disabling "unique" optimizations, they would only run slower, so `NOUNIQUE` will be ignored.
 
 !!! new "New in 6.0"

--- a/docs/src/markdown/glob.md
+++ b/docs/src/markdown/glob.md
@@ -151,7 +151,7 @@ And if we apply an exclusion pattern, since the patterns share the same context,
 
 ```pycon3
 >>> from wcmatch import glob
->>> glob.glob(['*.md', 'README.md', '!README.md'], flags=glob.NEGATE)
+>>> glob.glob(['*.md', '!README.md'], flags=glob.NEGATE)
 ['LICENSE.md']
 ```
 
@@ -160,7 +160,7 @@ multiple patterns. These features, when enabled and used, will also exhibit this
 
 ```pycon3
 >>> from wcmatch import glob
->>> glob.glob('{*,README}.md', flags=glob.BRACE)
+>>> glob.glob('{*,README}.md', flags=glob.BRACE | glob.NOUNIQUE)
 ['LICENSE.md', 'README.md', 'README.md']
 ```
 
@@ -169,6 +169,16 @@ This also aligns with Bash's behavior:
 ```console
 $ echo {*,README}.md
 LICENSE.md README.md README.md
+```
+
+It can be noted that we used the [`NOUNIQUE`](#globnounique) flag in the above example. That is because we filter out
+duplicate results by default. In order to get results without this filtering, you must use [`NOUNIQUE`](#globnounique).
+If we omit the flag, duplicates are removed:
+
+```pycon3
+>>> from wcmatch import glob
+>>> glob.glob('{*,README}.md', flags=glob.BRACE | glob.NOUNIQUE)
+['LICENSE.md', 'README.md']
 ```
 
 You can resolve user paths with `~` if the [`GLOBTILDE`](#globglobtilde) flag is enabled. You can also target specific

--- a/docs/src/markdown/glob.md
+++ b/docs/src/markdown/glob.md
@@ -560,6 +560,10 @@ Alternatively `EXTMATCH` will also be accepted for consistency with the other pr
 the same and are provided as a convenience in case the user finds one more intuitive than the other since `EXTGLOB` is
 often the name used in Bash.
 
+!!! tip "EXTMATCH and NEGATE"
+    When using `EXTMATCH` and [`NEGATE`](#globnegate) together, it is recommended to also use
+    [`MINUSNEGATE`](#globminusnegate) to avoid conflicts in regards to the `!` meta character.
+
 #### `glob.BRACE, glob.B` {: #globbrace}
 
 `BRACE` enables Bash style brace expansion: `a{b,{c,d}}` --> `ab ac ad`. Brace expansion is applied before anything
@@ -568,9 +572,16 @@ else. When applied, a pattern will be expanded into multiple patterns. Each patt
 For simple patterns, it may make more sense to use [`EXTGLOB`](#globextglob) which will only generate a single pattern:
 `@(ab|ac|ad)`.
 
-Be careful with patterns such as `{1..100}` which would generate one hundred patterns that will all get individually
-parsed. Sometimes you really need such a pattern, but be mindful that it will be slower as you generate larger sets of
-patterns.
+!!! warning "Using BRACE responsibly"
+    Be careful with patterns such as `{1..100}` which would generate one hundred patterns that will all get individually
+    parsed. Sometimes you really need such a pattern, but be mindful that it will be slower as you generate larger sets
+    of patterns. Especially with [`glob`](#globglob) and [`iglob`](#globiglob) which will crawl your file system for
+    each pattern.
+
+!!! tip "BRACE vs SPLIT"
+    `BRACE` and [`SPLIT`](#globsplit) both expand patterns into multiple patterns. While using them together will
+    work, it can also cause numerous duplicate patterns. If using either [`glob`](#globglob) or [`iglob`](#globiglob),
+    it is recommended to use one or the other. See [`BRACE vs SPLIT`](#brace-vs-split) for more info.
 
 #### `glob.GLOBTILDE, glob.T` {: #globglobtilde}
 
@@ -614,6 +625,13 @@ True
 >>> glob.globmatch('test.py', r'*.txt|*.py', flags=fnmatch.SPLIT)
 True
 ```
+
+`SPLIT` syntax also pairs really well with [`EXTGLOB`](#globextglob).
+
+!!! tip "BRACE vs SPLIT"
+    [`BRACE`](#globbrace) and `SPLIT` both expand patterns into multiple patterns. While using them together will work,
+    it can also cause numerous duplicate patterns. If using either [`glob`](#globglob) or [`iglob`](#globiglob), it is
+    recommended to use one or the other. See [`BRACE vs SPLIT`](#brace-vs-split) for more info.
 
 #### `glob.MARK, glob.K` {: #globmark}
 
@@ -694,6 +712,64 @@ If `FORCEUNIX` is used along side [`FORCEWIN`](#globforcewin), both will be igno
 
 !!! new "New 4.2"
     `FORCEUNIX` is new in 4.2.0.
+
+
+## BRACE vs SPLIT
+
+When using [`glob`](#globglob), [`iglob`](#globiglob), or even [`pathlib`](./pathlib.md)'s
+[`rglob`](./pathlib.md#pathrglob), it is recommended not to use [`BRACE`](#globbrace) syntax while *also* using
+[`SPLIT`](#globsplit) syntax as it can cause a lot of duplicate patterns that can slow down performance. This is
+particularly problematic with functions that crawl the file system as they will re-crawl the file system for every
+pattern.
+
+For instance, if  [`BRACE`](#globbrace) and [`SPLIT`](#globsplit) were enabled for
+`#!py3 'test@(this{|that,|other})|*.py'`, it would expand to:
+
+```py3
+# Multiple *.py patterns!
+['test@(this|that)', '*.py', 'test@(this|other)', '*.py']
+```
+
+Matching functions such as [`globfilter`](#globglobfilter), [`globmatch`](#globglobmatch), etc. will remove these
+duplicate patterns as they are meant to simply match paths. File crawling functions like [`glob`](#globglob), etc. are
+much like Bash's glob, they give you exactly what you ask for, even if it's the same thing over and over :slight_smile:.
+
+[`BRACE`](#globbrace) is extremely powerful, but can be a bit awkward when specifying multiple long patterns:
+
+```
+{somepath/**/more-path/*.py,some-other-path/**/*.txt}
+```
+
+It can also be easy to create careless patterns that can cause a file system to be inefficiently crawled many times.
+Like this pattern which will generate 300 separate patterns.
+
+```
+**/file-{1..100}.{py,md,txt}
+```
+
+But when used smartly, [`BRACE`](#globbrace) can be quite useful.
+
+On the other hand [`SPLIT`](#globsplit), while less powerful, is less cumbersome with multiple long patterns. You
+simply separate them with `|`:
+
+```
+somepath/**/more-path/*.py|some-other-path/**/*.txt
+```
+
+[`SPLIT`](#globsplit) also pairs nicely with [`EXTGLOB`](#globextglob) with a complementary feel and syntax:
+
+```
+somepath/**/more-path/*.@(py|pyc)|some-other-path/**/*.txt
+```
+
+With that said, [`EXTGLOB`](#globextglob) also works with [`BRACE`](#globbrace):
+
+```
+{somepath/**/more-path/*.@(py|pyc),some-other-path/**/*.txt}
+```
+
+Having both enabled isn't a problem, but you would want to be mindful when you are constructing patterns to choose one
+over the other.
 
 --8<--
 refs.txt

--- a/docs/src/markdown/pathlib.md
+++ b/docs/src/markdown/pathlib.md
@@ -404,6 +404,10 @@ Alternatively `EXTMATCH` will also be accepted for consistency with the other pr
 the same and are provided as a convenience in case the user finds one more intuitive than the other since `EXTGLOB` is
 often the name used in Bash.
 
+!!! tip "EXTMATCH and NEGATE"
+    When using `EXTMATCH` and [`NEGATE`](#pathlibnegate) together, it is recommended to also use
+    [`MINUSNEGATE`](#pathlibminusnegate) to avoid conflicts in regards to the `!` meta character.
+
 #### `pathlib.BRACE, pathlib.B` {: #pathlibbrace}
 
 `BRACE` enables Bash style brace expansion: `a{b,{c,d}}` --> `ab ac ad`. Brace expansion is applied before anything
@@ -412,9 +416,17 @@ else. When applied, a pattern will be expanded into multiple patterns. Each patt
 For simple patterns, it may make more sense to use [`EXTGLOB`](#pathlibextglob) which will only generate a single
 pattern: `@(ab|ac|ad)`.
 
-Be careful with patterns such as `{1..100}` which would generate one hundred patterns that will all get individually
-parsed. Sometimes you really need such a pattern, but be mindful that it will be slower as you generate larger sets of
-patterns.
+!!! warning "Using BRACE responsibly"
+    Be careful with patterns such as `{1..100}` which would generate one hundred patterns that will all get individually
+    parsed. Sometimes you really need such a pattern, but be mindful that it will be slower as you generate larger sets
+    of patterns. Especially with [`glob`](#pathglob) and [`rglob`](#pathrglob) which will crawl your file system for
+    each pattern.
+
+!!! tip "BRACE vs SPLIT"
+    `BRACE` and [`SPLIT`](#pathlibsplit) both expand patterns into multiple patterns. While using them together will
+    work, it can also cause numerous duplicate patterns. If using either [`glob`](#pathglob) or
+    [`rglob`](#pathrglob), it is recommended to use one or the other. See [`BRACE vs SPLIT`](./glob.md#brace-vs-split)
+    for more info.
 
 #### `pathlib.SPLIT, pathlib.S` {: #pathlibsplit}
 
@@ -428,6 +440,13 @@ escape the delimiters if needed: `\|`.
 >>> list(pathlib.Path('.').glob('README.md|LICENSE.md', flags=pathlib.SPLIT))
 [WindowsPath('README.md'), WindowsPath('LICENSE.md')]
 ```
+
+`SPLIT` syntax also pairs really well with [`EXTGLOB`](#pathlibextglob).
+
+!!! tip "BRACE vs SPLIT"
+    [`BRACE`](#pathlibbrace) and `SPLIT` both expand patterns into multiple patterns. While using them together will
+    work, it can also cause numerous duplicate patterns. If using either [`glob`](#pathglob) or [`rglob`](#pathrglob),
+    it is recommended to use one or the other. See [`BRACE vs SPLIT`](./glob.md#brace-vs-split) for more info.
 
 #### `pathlib.MATCHBASE, pathlib.X` {: #pathlibmatchbase}
 

--- a/docs/src/markdown/pathlib.md
+++ b/docs/src/markdown/pathlib.md
@@ -461,6 +461,31 @@ related to pairing it with `SPLIT`.
 [WindowsPath('README.md'), WindowsPath('LICENSE.md')]
 ```
 
+### `pathlib.NOUNIQUE, pathlib.Q` {: #pathlibnounique}
+
+`NOUNIQUE` is used to disable Wildcard Match's unique results return. This mimics Bash's output behavior if that is
+desired.
+
+```pycon3
+>>> from wcmatch import glob
+>>> glob.glob('{*,README}.md', flags=glob.BRACE | glob.NOUNIQUE)
+['LICENSE.md', 'README.md', 'README.md']
+>>> glob.glob('{*,README}.md', flags=glob.BRACE )
+['LICENSE.md', 'README.md']
+```
+
+By default, only unique paths are returned in [`glob`](#pathglob) and [`rglob`](#pathrglob). Normally this is what a
+programmer would want from such a library, so input patterns are reduced to unique patterns[^1] to reduce excessive
+matching with redundant patterns and excessive crawls through the file system. Also, as two different patterns that have
+been fed into [`glob`](#pathglob) may match the same file, the results are also filtered as to not return duplicates.
+
+`NOUNIQUE` disables all of the aforementioned "unique" optimizations, but only for [`glob`](#globglob) and
+[`rglob`](#pathrglob). Functions like [`globmatch`](#purepathglobmatch) and [`match`](#purepathmatch) would get no
+benefit from disabling "unique" optimizations, they would only run slower, so `NOUNIQUE` will be ignored.
+
+!!! new "New in 6.0"
+    "Unique" optimizations were added in 6.0, along with `NOUNIQUE`.
+
 #### `pathlib.MATCHBASE, pathlib.X` {: #pathlibmatchbase}
 
 `MATCHBASE`, when a pattern has no slashes in it, will cause all glob related functions to seek for any file anywhere in

--- a/docs/src/markdown/pathlib.md
+++ b/docs/src/markdown/pathlib.md
@@ -19,6 +19,16 @@ introduced by Wildcard Match's implementation. Please check out Python's [`pathl
 more about [`pathlib`][pathlib] in general. Also, to learn more about the underlying glob library being used, check out
 the documentation for Wildcard Match's [`glob`](./glob.md).
 
+## Multi-Pattern Limits
+
+Many of the API functions allow passing in multiple patterns or using either [`BRACE`](#pathlibbrace) or
+[`SPLIT`](#pathlibsplit) to expand a pattern in to more patterns. The number of allowed patterns is limited `1000`, but
+you can raise or lower this limit via the keyword option `limit`. If you set `limit` to `0`, there will
+be no limit.
+
+!!! new "New 6.0"
+    The imposed pattern limit and corresponding `limit` option was introduced in 6.0.
+
 ### Differences
 
 The API is the same as Python's default [`pathlib`][pathlib] except for the few differences related to file globbing and
@@ -203,11 +213,12 @@ PosixPath('/usr/local/bin')
 #### `PurePath.match`
 
 ```py3
-def match(self, patterns, *, flags=0):
+def match(self, patterns, *, flags=0, limit=1000):
 ```
 
-`match` takes a pattern (or list of patterns), and flags.  It will return a boolean indicating whether the objects
-file path was matched by the pattern(s).
+`match` takes a pattern (or list of patterns), and flags.  It also allows configuring the [max pattern
+limit](#multi-pattern-limits). It will return a boolean indicating whether the objects file path was matched by the
+pattern(s).
 
 `match` mimics Python's `pathlib` version of `match` in that it uses a recursive logic. What this means is when you are
 matching a path in the form `some/path/name`, the patterns `name`, `path/name` and `some/path/name` will all match.
@@ -229,14 +240,18 @@ Since [`Path`](#pathlibpath) is derived from [`PurePath`](#pathlibpurepath), thi
 True
 ```
 
+!!! new "New 6.0"
+    `limit` was added in 6.0.
+
 #### `PurePath.globmatch`
 
 ```py3
-def globmatch(self, patterns, *, flags=0):
+def globmatch(self, patterns, *, flags=0, limit=1000):
 ```
 
-`globmatch` takes a pattern (or list of patterns), and flags.  It will return a boolean indicating whether the objects
-file path was matched by the pattern(s).
+`globmatch` takes a pattern (or list of patterns), and flags.  It also allows configuring the [max pattern
+limit](#multi-pattern-limits).It will return a boolean indicating whether the objects file path was matched by the
+pattern(s).
 
 `globmatch` is similar to [`match`](#purepathmatch) except it does not use the same recursive logic that
 [`match`](#purepathmatch) does. In all other respects, it behaves the same.
@@ -256,16 +271,20 @@ Since [`Path`](#pathlibpath) is derived from  [`PurePath`](#pathlibpurepath), th
 True
 ```
 
+!!! new "New 6.0"
+    `limit` was added in 6.0.
+
 #### `Path.glob`
 
 ```py3
-def glob(self, patterns, *, flags=0):
+def glob(self, patterns, *, flags=0, limit=1000):
 ```
 
-`glob` takes a pattern (or list of patterns) and will crawl the file system, relative to the current
-[`Path`](#pathlibpath) object, returning a generator of [`Path`](#pathlibpath) objects. If a file/folder matches any
-regular, inclusion pattern, it is considered a match.  If a file matches *any* exclusion pattern (when enabling the
-[`NEGATE`](#pathlibnegate) flag), then it will not be returned.
+`glob` takes a pattern (or list of patterns) and flags. It also allows configuring the [max pattern
+limit](#multi-pattern-limits). It will crawl the file system, relative to the current [`Path`](#pathlibpath) object,
+returning a generator of [`Path`](#pathlibpath) objects. If a file/folder matches any regular, inclusion pattern, it is
+considered a match.  If a file matches *any* exclusion pattern (when enabling the [`NEGATE`](#pathlibnegate) flag), then
+it will not be returned.
 
 This method calls our own [`iglob`](./glob.md#globiglob) implementation, and as such, should behave in the same manner
 in respect to features, the one exception being that instead of returning path strings in the generator, it will return
@@ -282,16 +301,20 @@ working directory.
 [PosixPath('docs/src/dictionary/en-custom.txt'), PosixPath('docs/src/markdown/_snippets/links.txt'), PosixPath('docs/src/markdown/_snippets/refs.txt'), PosixPath('docs/src/markdown/_snippets/abbr.txt'), PosixPath('docs/src/markdown/_snippets/posix.txt')]
 ```
 
+!!! new "New 6.0"
+    `limit` was added in 6.0.
+
 #### `Path.rglob`
 
 ```py3
-def rglob(self, patterns, *, flags=0):
+def rglob(self, patterns, *, flags=0, path_limit=1000):
 ```
 
-`rglob` takes a pattern (or list of patterns) and will crawl the file system, relative to the current
-[`Path`](#pathlibpath) object, returning a generator of [`Path`](#pathlibpath) objects. If a file/folder matches any
-regular patterns, it is considered a match.  If a file matches *any* exclusion pattern (when enabling the
-[`NEGATE`](#pathlibnegate) flag), then it will be not be returned.
+`rglob` takes a pattern (or list of patterns) and flags. It also allows configuring the [max pattern
+limit](#multi-pattern-limits). It will crawl the file system, relative to the current [`Path`](#pathlibpath) object,
+returning a generator of [`Path`](#pathlibpath) objects. If a file/folder matches any regular patterns, it is considered
+a match.  If a file matches *any* exclusion pattern (when enabling the [`NEGATE`](#pathlibnegate) flag), then it will be
+not be returned.
 
 `rglob` mimics Python's [`pathlib`][pathlib] version of `rglob` in that it uses a recursive logic. What this means is
 that when you are matching a path in the form `some/path/name`, the patterns `name`, `path/name` and `some/path/name`
@@ -307,6 +330,9 @@ the same.
 >>> list(p.rglob('*.txt'))
 [PosixPath('docs/src/dictionary/en-custom.txt'), PosixPath('docs/src/markdown/_snippets/links.txt'), PosixPath('docs/src/markdown/_snippets/refs.txt'), PosixPath('docs/src/markdown/_snippets/abbr.txt'), PosixPath('docs/src/markdown/_snippets/posix.txt')]
 ```
+
+!!! new "New 6.0"
+    `limit` was added in 6.0.
 
 ## Flags
 

--- a/docs/src/markdown/wcmatch.md
+++ b/docs/src/markdown/wcmatch.md
@@ -326,6 +326,10 @@ handle standard string escapes and Unicode (including `#!py3 r'\N{CHAR NAME}'`).
 `EXTMATCH` enables extended pattern matching which includes special pattern lists such as `+(...)`, `*(...)`, `?(...)`,
 etc.
 
+!!! tip "EXTMATCH and NEGATE"
+    When using `EXTMATCH`, it is recommended to also use [`MINUSNEGATE`](#wcmatchminusnegate) to avoid conflicts in
+    regards to the `!` meta character which is used for exclusion patterns..
+
 #### `wcmatch.BRACE, wcmatch.B` {: #wcmatchbrace}
 
 `BRACE` enables Bash style brace expansion: `a{b,{c,d}}` --> `ab ac ad`. Brace expansion is applied before anything
@@ -334,9 +338,10 @@ else. When applied, a pattern will be expanded into multiple patterns. Each patt
 For simple patterns, it may make more sense to use [`EXTMATCH`](#wcmatchextmatch) which will only generate a single
 pattern: `@(ab|ac|ad)`.
 
-Be careful with patterns such as `{1..100}` which would generate one hundred patterns that will all get individually
-parsed. Sometimes you really need such a pattern, but be mindful that it will be slower as you generate larger sets of
-patterns.
+!!! warning "Using BRACE Responsibly"
+    Be careful with patterns such as `{1..100}` which would generate one hundred patterns that will all get individually
+    parsed. Sometimes you really need such a pattern, but be mindful that it will be slower as you generate larger sets
+    of patterns.
 
 #### `wcmatch.MINUSNEGATE, wcmatch.M` {: #wcmatchminusnegate}
 

--- a/docs/src/markdown/wcmatch.md
+++ b/docs/src/markdown/wcmatch.md
@@ -27,6 +27,7 @@ Parameter         | Default       | Description
 `file_pattern`    | `#!py3 ''`    | One or more patterns separated by `|`. You can define exceptions by starting a pattern with `!` (or `-` if [`MINUSNEGATE`](#wcmatchminusnegate) is set). The default is an empty string, but if an empty string is used, all files will be matched.
 `exclude_pattern` | `#!py3 ''`    | Zero or more folder exclude patterns separated by `|`. You can define exceptions by starting a pattern with `!` (or `-` if [`MINUSNEGATE`](#wcmatchminusnegate) is set).
 `flags`           | `#!py3 0`     | Flags to alter behavior of folder and file matching. See [Flags](#flags) for more info.
+`limit`   | `#!py3 1000`  | Allows configuring the [max pattern limit](#multi-pattern-limits).
 
 !!! note
     Dots are not treated special in `wcmatch`. When the `HIDDEN` flag is not included, all hidden files (system and dot
@@ -36,6 +37,18 @@ Parameter         | Default       | Description
 !!! danger "Removed in 3.0"
     `show_hidden` and `recursive` were removed to provide a more consistent interface. Hidden files and recursion can be
     enabled via the [`HIDDEN`](#wcmatchhidden) and [`RECURSIVE`](#wcmatchrecursive) flag respectively.
+
+!!! new "New 6.0"
+    `limit` was added in 6.0.
+
+### Multi-Pattern Limits
+
+The `WcMatch` class allow expanding a pattern into multiple patterns by using `|` and by using [`BRACE`](#wcmatchbrace).
+The number of allowed patterns is limited `1000`, but you can raise or lower this limit via the keyword option
+`limit`. If you set `limit` to `0`, there will be no limit.
+
+!!! new "New 6.0"
+    The imposed pattern limit and corresponding `limit` option was introduced in 6.0.
 
 ### Examples
 
@@ -163,7 +176,7 @@ Resets the abort state after running `kill`.
 
 Checks if an abort has been issued.
 
-```
+```pycon3
 >>> from wcmatch import wcmatch
 >>> wcm = wcmatch.WcMatch('.', '*.md|*.txt')
 >>> for f in wcm.imatch():

--- a/tests/test_fnmatch.py
+++ b/tests/test_fnmatch.py
@@ -504,3 +504,25 @@ class TestFnMatchTranslate(unittest.TestCase):
 
         self.assertTrue(len(fnmatch.translate('!test', flags=fnmatch.N | fnmatch.A)[0]) == 1)
         self.assertTrue(len(fnmatch.translate(b'!test', flags=fnmatch.N | fnmatch.A)[0]) == 1)
+
+
+class TestExpansionLimit(unittest.TestCase):
+    """Test expansion limits."""
+
+    def test_limit_fnmatch(self):
+        """Test expansion limit of `fnmatch`."""
+
+        with self.assertRaises(_wcparse.PatternLimitException):
+            fnmatch.fnmatch('name', '{1..11}', flags=fnmatch.BRACE, pattern_limit=10)
+
+    def test_limit_filter(self):
+        """Test expansion limit of `filter`."""
+
+        with self.assertRaises(_wcparse.PatternLimitException):
+            fnmatch.filter(['name'], '{1..11}', flags=fnmatch.BRACE, pattern_limit=10)
+
+    def test_limit_translate(self):
+        """Test expansion limit of `translate`."""
+
+        with self.assertRaises(_wcparse.PatternLimitException):
+            fnmatch.translate('{1..11}', flags=fnmatch.BRACE, pattern_limit=10)

--- a/tests/test_fnmatch.py
+++ b/tests/test_fnmatch.py
@@ -350,19 +350,19 @@ class TestFnMatchTranslate(unittest.TestCase):
 
         p1, p2 = self.split_translate('|test|', flags)
         if util.PY36:
-            self.assertEqual(p1, [r'^(?s:)$', r'^(?s:test)$', r'^(?s:)$'])
+            self.assertEqual(p1, [r'^(?s:)$', r'^(?s:test)$'])
             self.assertEqual(p2, [])
         else:
-            self.assertEqual(p1, [r'(?s)^(?:)$', r'(?s)^(?:test)$', r'(?s)^(?:)$'])
+            self.assertEqual(p1, [r'(?s)^(?:)$', r'(?s)^(?:test)$'])
             self.assertEqual(p2, [])
 
         p1, p2 = self.split_translate('-|-test|-', flags=flags | fnmatch.N | fnmatch.M)
         if util.PY36:
             self.assertEqual(p1, [])
-            self.assertEqual(p2, [r'^(?s:)$', r'^(?s:test)$', r'^(?s:)$'])
+            self.assertEqual(p2, [r'^(?s:)$', r'^(?s:test)$'])
         else:
             self.assertEqual(p1, [])
-            self.assertEqual(p2, [r'(?s)^(?:)$', r'(?s)^(?:test)$', r'(?s)^(?:)$'])
+            self.assertEqual(p2, [r'(?s)^(?:)$', r'(?s)^(?:test)$'])
 
         p1, p2 = self.split_translate('test[^chars]', flags)
         if util.PY36:

--- a/tests/test_fnmatch.py
+++ b/tests/test_fnmatch.py
@@ -513,16 +513,16 @@ class TestExpansionLimit(unittest.TestCase):
         """Test expansion limit of `fnmatch`."""
 
         with self.assertRaises(_wcparse.PatternLimitException):
-            fnmatch.fnmatch('name', '{1..11}', flags=fnmatch.BRACE, pattern_limit=10)
+            fnmatch.fnmatch('name', '{1..11}', flags=fnmatch.BRACE, limit=10)
 
     def test_limit_filter(self):
         """Test expansion limit of `filter`."""
 
         with self.assertRaises(_wcparse.PatternLimitException):
-            fnmatch.filter(['name'], '{1..11}', flags=fnmatch.BRACE, pattern_limit=10)
+            fnmatch.filter(['name'], '{1..11}', flags=fnmatch.BRACE, limit=10)
 
     def test_limit_translate(self):
         """Test expansion limit of `translate`."""
 
         with self.assertRaises(_wcparse.PatternLimitException):
-            fnmatch.translate('{1..11}', flags=fnmatch.BRACE, pattern_limit=10)
+            fnmatch.translate('{1..11}', flags=fnmatch.BRACE, limit=10)

--- a/tests/test_glob.py
+++ b/tests/test_glob.py
@@ -1198,10 +1198,10 @@ class TestExpansionLimit(unittest.TestCase):
         """Test expansion limit of `glob`."""
 
         with self.assertRaises(_wcparse.PatternLimitException):
-            glob.glob('{1..11}', flags=glob.BRACE, pattern_limit=10)
+            glob.glob('{1..11}', flags=glob.BRACE, limit=10)
 
     def test_limit_iglob(self):
         """Test expansion limit of `iglob`."""
 
         with self.assertRaises(_wcparse.PatternLimitException):
-            list(glob.iglob('{1..11}', flags=glob.BRACE, pattern_limit=10))
+            list(glob.iglob('{1..11}', flags=glob.BRACE, limit=10))

--- a/tests/test_glob.py
+++ b/tests/test_glob.py
@@ -12,6 +12,7 @@ made difference in implementation.
 import contextlib
 from wcmatch import glob
 from wcmatch import pathlib
+from wcmatch import _wcparse
 from wcmatch import util
 import re
 import types
@@ -1188,3 +1189,19 @@ class TestTilde(unittest.TestCase):
         """Test when tilde is disabled."""
 
         self.assertEqual(len(glob.glob('~/*', flags=glob.D)), 0)
+
+
+class TestExpansionLimit(unittest.TestCase):
+    """Test expansion limits."""
+
+    def test_limit_glob(self):
+        """Test expansion limit of `glob`."""
+
+        with self.assertRaises(_wcparse.PatternLimitException):
+            glob.glob('{1..11}', flags=glob.BRACE, pattern_limit=10)
+
+    def test_limit_iglob(self):
+        """Test expansion limit of `iglob`."""
+
+        with self.assertRaises(_wcparse.PatternLimitException):
+            list(glob.iglob('{1..11}', flags=glob.BRACE, pattern_limit=10))

--- a/tests/test_glob.py
+++ b/tests/test_glob.py
@@ -864,13 +864,13 @@ class Testglob(_TestGlob):
         """Negate applied to all files."""
 
         for file in glob.glob('!**/', flags=glob.N | glob.NEGATEALL | glob.G, root_dir=self.tempdir):
-            self.assertFalse(os.path.isdir(file))
+            self.assert_equal(os.path.isdir(file), False)
 
     def test_negateall_bytes(self):
         """Negate applied to all files."""
 
         for file in glob.glob(b'!**/', flags=glob.N | glob.NEGATEALL | glob.G, root_dir=os.fsencode(self.tempdir)):
-            self.assertFalse(os.path.isdir(file))
+            self.assert_equal(os.path.isdir(file), False)
 
 
 class TestGlobMarked(Testglob):

--- a/tests/test_glob.py
+++ b/tests/test_glob.py
@@ -395,6 +395,12 @@ class Testglob(_TestGlob):
         [('[.a]',), [('a',)]],
         [('*.',), []],
 
+        # Glob with braces
+        [('{a*,a*}',), [('a',), ('aab',), ('aaa',)]],
+
+        # Glob with braces and "unique" turned off
+        [('{a*,a*}',), [('a',), ('aab',), ('aaa',), ('a',), ('aab',), ('aaa',)], glob.Q],
+
         Options(default_negate='**'),
         # Glob inverse
         [

--- a/tests/test_globmatch.py
+++ b/tests/test_globmatch.py
@@ -1499,16 +1499,16 @@ class TestExpansionLimit(unittest.TestCase):
         """Test expansion limit of `globmatch`."""
 
         with self.assertRaises(_wcparse.PatternLimitException):
-            glob.globmatch('name', '{1..11}', flags=glob.BRACE, pattern_limit=10)
+            glob.globmatch('name', '{1..11}', flags=glob.BRACE, limit=10)
 
     def test_limit_filter(self):
         """Test expansion limit of `globfilter`."""
 
         with self.assertRaises(_wcparse.PatternLimitException):
-            glob.globfilter(['name'], '{1..11}', flags=glob.BRACE, pattern_limit=10)
+            glob.globfilter(['name'], '{1..11}', flags=glob.BRACE, limit=10)
 
     def test_limit_translate(self):
         """Test expansion limit of `translate`."""
 
         with self.assertRaises(_wcparse.PatternLimitException):
-            glob.translate('{1..11}', flags=glob.BRACE, pattern_limit=10)
+            glob.translate('{1..11}', flags=glob.BRACE, limit=10)

--- a/tests/test_globmatch.py
+++ b/tests/test_globmatch.py
@@ -1490,3 +1490,25 @@ class TestTilde(unittest.TestCase):
         )
 
         self.assertNotEqual(len(files), len(gfiles))
+
+
+class TestExpansionLimit(unittest.TestCase):
+    """Test expansion limits."""
+
+    def test_limit_globmatch(self):
+        """Test expansion limit of `globmatch`."""
+
+        with self.assertRaises(_wcparse.PatternLimitException):
+            glob.globmatch('name', '{1..11}', flags=glob.BRACE, pattern_limit=10)
+
+    def test_limit_filter(self):
+        """Test expansion limit of `globfilter`."""
+
+        with self.assertRaises(_wcparse.PatternLimitException):
+            glob.globfilter(['name'], '{1..11}', flags=glob.BRACE, pattern_limit=10)
+
+    def test_limit_translate(self):
+        """Test expansion limit of `translate`."""
+
+        with self.assertRaises(_wcparse.PatternLimitException):
+            glob.translate('{1..11}', flags=glob.BRACE, pattern_limit=10)

--- a/tests/test_pathlib.py
+++ b/tests/test_pathlib.py
@@ -3,7 +3,7 @@ import contextlib
 import pytest
 import unittest
 import os
-from wcmatch import pathlib, glob
+from wcmatch import pathlib, glob, _wcparse
 import pathlib as pypathlib
 import pickle
 import warnings
@@ -343,3 +343,31 @@ class TestComparisons(unittest.TestCase):
         self.assertTrue(type(p2) == type(p4))
         self.assertTrue(type(p1) != type(p2))
         self.assertTrue(type(p3) != type(p4))
+
+
+class TestExpansionLimit(unittest.TestCase):
+    """Test expansion limits."""
+
+    def test_limit_globmatch(self):
+        """Test expansion limit of `globmatch`."""
+
+        with self.assertRaises(_wcparse.PatternLimitException):
+            pathlib.PurePath('name').globmatch('{1..11}', flags=pathlib.BRACE, pattern_limit=10)
+
+    def test_limit_match(self):
+        """Test expansion limit of `match`."""
+
+        with self.assertRaises(_wcparse.PatternLimitException):
+            pathlib.PurePath('name').match('{1..11}', flags=pathlib.BRACE, pattern_limit=10)
+
+    def test_limit_glob(self):
+        """Test expansion limit of `glob`."""
+
+        with self.assertRaises(_wcparse.PatternLimitException):
+            list(pathlib.Path('.').glob('{1..11}', flags=pathlib.BRACE, pattern_limit=10))
+
+    def test_limit_rglob(self):
+        """Test expansion limit of `rglob`."""
+
+        with self.assertRaises(_wcparse.PatternLimitException):
+            list(pathlib.Path('.').rglob('{1..11}', flags=pathlib.BRACE, pattern_limit=10))

--- a/tests/test_pathlib.py
+++ b/tests/test_pathlib.py
@@ -352,22 +352,22 @@ class TestExpansionLimit(unittest.TestCase):
         """Test expansion limit of `globmatch`."""
 
         with self.assertRaises(_wcparse.PatternLimitException):
-            pathlib.PurePath('name').globmatch('{1..11}', flags=pathlib.BRACE, pattern_limit=10)
+            pathlib.PurePath('name').globmatch('{1..11}', flags=pathlib.BRACE, limit=10)
 
     def test_limit_match(self):
         """Test expansion limit of `match`."""
 
         with self.assertRaises(_wcparse.PatternLimitException):
-            pathlib.PurePath('name').match('{1..11}', flags=pathlib.BRACE, pattern_limit=10)
+            pathlib.PurePath('name').match('{1..11}', flags=pathlib.BRACE, limit=10)
 
     def test_limit_glob(self):
         """Test expansion limit of `glob`."""
 
         with self.assertRaises(_wcparse.PatternLimitException):
-            list(pathlib.Path('.').glob('{1..11}', flags=pathlib.BRACE, pattern_limit=10))
+            list(pathlib.Path('.').glob('{1..11}', flags=pathlib.BRACE, limit=10))
 
     def test_limit_rglob(self):
         """Test expansion limit of `rglob`."""
 
         with self.assertRaises(_wcparse.PatternLimitException):
-            list(pathlib.Path('.').rglob('{1..11}', flags=pathlib.BRACE, pattern_limit=10))
+            list(pathlib.Path('.').rglob('{1..11}', flags=pathlib.BRACE, limit=10))

--- a/tests/test_wcmatch.py
+++ b/tests/test_wcmatch.py
@@ -4,6 +4,7 @@ import unittest
 import os
 import wcmatch.wcmatch as wcmatch
 import shutil
+from wcmatch import _wcparse
 
 
 # Below is general helper stuff that Python uses in `unittests`.  As these
@@ -566,3 +567,13 @@ class TestWcmatchSymlink(_TestWcmatch):
                 ['a.txt', '.hidden/a.txt']
             )
         )
+
+
+class TestExpansionLimit(unittest.TestCase):
+    """Test expansion limits."""
+
+    def test_limit_wcmatch(self):
+        """Test expansion limit of `globmatch`."""
+
+        with self.assertRaises(_wcparse.PatternLimitException):
+            wcmatch.WcMatch('.', '{1..11}', flags=wcmatch.BRACE, pattern_limit=10)

--- a/tests/test_wcmatch.py
+++ b/tests/test_wcmatch.py
@@ -576,4 +576,4 @@ class TestExpansionLimit(unittest.TestCase):
         """Test expansion limit of `globmatch`."""
 
         with self.assertRaises(_wcparse.PatternLimitException):
-            wcmatch.WcMatch('.', '{1..11}', flags=wcmatch.BRACE, pattern_limit=10)
+            wcmatch.WcMatch('.', '{1..11}', flags=wcmatch.BRACE, limit=10)

--- a/tests/test_wcparse.py
+++ b/tests/test_wcparse.py
@@ -78,3 +78,15 @@ class TestWcparse(unittest.TestCase):
                 '{{{},{}}}'.format('|'.join(['a'] * 6), '|'.join(['a'] * 5)),
                 _wcparse.SPLIT | _wcparse.BRACE, 10
             )
+
+    def test_expansion_no_limit_compile(self):
+        """Test no expansion limit compile."""
+
+        self.assertEqual(len(_wcparse.compile('{1..11}', _wcparse.BRACE, -1)), 11)
+
+    def test_expansion_no_limit_translate(self):
+        """Test no expansion limit translate."""
+
+        p1, p2 = _wcparse.translate('{1..11}', _wcparse.BRACE, 0)
+        count = len(p1) + len(p2)
+        self.assertEqual(count, 11)

--- a/tests/test_wcparse.py
+++ b/tests/test_wcparse.py
@@ -40,3 +40,41 @@ class TestWcparse(unittest.TestCase):
             _wcparse.BRACE | _wcparse.SPLIT | _wcparse.EXTMATCH
         )
         self.assertEqual(sorted(results), sorted(['test@(this|that)', 'test@(this|other)', '*.py', '*.py']))
+
+    def test_compile_expansion_okay(self):
+        """Test expansion is okay."""
+
+        self.assertEqual(len(_wcparse.compile('{1..10}', _wcparse.BRACE)), 10)
+
+    def test_compile_unique_optimization_okay(self):
+        """Test that redundant patterns are reduced in compile."""
+
+        self.assertEqual(len(_wcparse.compile('|'.join(['a'] * 10), _wcparse.SPLIT, 10)), 1)
+
+    def test_translate_expansion_okay(self):
+        """Test expansion is okay."""
+
+        p1, p2 = _wcparse.translate('{1..10}', _wcparse.BRACE, 10)
+        count = len(p1) + len(p2)
+        self.assertEqual(count, 10)
+
+    def test_translate_unique_optimization_okay(self):
+        """Test that redundant patterns are reduced in translate."""
+        p1, p2 = _wcparse.translate('|'.join(['a'] * 10), _wcparse.SPLIT, 10)
+        count = len(p1) + len(p2)
+        self.assertEqual(count, 1)
+
+    def test_expansion_limt(self):
+        """Test expansion limit."""
+
+        with self.assertRaises(_wcparse.PatternLimitException):
+            _wcparse.compile('{1..11}', _wcparse.BRACE, 10)
+
+        with self.assertRaises(_wcparse.PatternLimitException):
+            _wcparse.compile('|'.join(['a'] * 11), _wcparse.SPLIT, 10)
+
+        with self.assertRaises(_wcparse.PatternLimitException):
+            _wcparse.compile(
+                '{{{},{}}}'.format('|'.join(['a'] * 6), '|'.join(['a'] * 5)),
+                _wcparse.SPLIT | _wcparse.BRACE, 10
+            )

--- a/tests/test_wcparse.py
+++ b/tests/test_wcparse.py
@@ -31,3 +31,13 @@ class TestWcparse(unittest.TestCase):
         w6 = copy.copy(w1)
         self.assertTrue(w1 == w6)
         self.assertTrue(w6 in {w1})
+
+    def test_preprocessor_sequence(self):
+        """Test the integrity of the order of preprocessors."""
+
+        results = _wcparse.expand(
+            'test@(this{|that,|other})|*.py',
+            False,
+            _wcparse.BRACE | _wcparse.SPLIT | _wcparse.EXTMATCH
+        )
+        self.assertEqual(sorted(results), sorted(['test@(this|that)', '*.py', 'test@(this|other)', '*.py']))

--- a/tests/test_wcparse.py
+++ b/tests/test_wcparse.py
@@ -37,7 +37,6 @@ class TestWcparse(unittest.TestCase):
 
         results = _wcparse.expand(
             'test@(this{|that,|other})|*.py',
-            False,
             _wcparse.BRACE | _wcparse.SPLIT | _wcparse.EXTMATCH
         )
-        self.assertEqual(sorted(results), sorted(['test@(this|that)', '*.py', 'test@(this|other)', '*.py']))
+        self.assertEqual(sorted(results), sorted(['test@(this|that)', 'test@(this|other)', '*.py', '*.py']))

--- a/wcmatch/__meta__.py
+++ b/wcmatch/__meta__.py
@@ -186,5 +186,5 @@ def parse_version(ver, pre=False):
     return Version(major, minor, micro, release, pre, post, dev)
 
 
-__version_info__ = Version(5, 2, 0, ".dev")
+__version_info__ = Version(6, 0, 0, ".dev")
 __version__ = __version_info__._get_canonical()

--- a/wcmatch/_wcparse.py
+++ b/wcmatch/_wcparse.py
@@ -602,7 +602,10 @@ class WcPathSplit(object):
         magic = self.is_magic(value)
         if magic:
             value = _compile(value, self.flags)
-        l.append(WcGlob(value, magic, globstar, dir_only, False))
+        if globstar and l and l[-1].is_globstar:
+            l[-1] = WcGlob(value, magic, globstar, dir_only, False)
+        else:
+            l.append(WcGlob(value, magic, globstar, dir_only, False))
 
     def split(self):
         """Start parsing the pattern."""

--- a/wcmatch/_wcparse.py
+++ b/wcmatch/_wcparse.py
@@ -431,7 +431,7 @@ def compile(patterns, flags, pattern_limit=PATTERN_LIMIT):  # noqa A001
     count = 1
 
     for pattern in patterns:
-        for expanded in set(expand(util.norm_pattern(pattern, not is_unix, flags & RAWCHARS), flags)):
+        for expanded in expand(util.norm_pattern(pattern, not is_unix, flags & RAWCHARS), flags):
             if 0 <= pattern_limit < count:
                 raise PatternLimitException("Pattern limit exceeded the limit of {:d}".format(pattern_limit))
             if expanded in seen:
@@ -1664,6 +1664,11 @@ class WcRegexp(util.Immutable):
         """Hash."""
 
         return self._hash
+
+    def __len__(self):
+        """Length."""
+
+        return len(self._include) + len(self._exclude)
 
     def __eq__(self, other):
         """Equal."""

--- a/wcmatch/_wcparse.py
+++ b/wcmatch/_wcparse.py
@@ -372,7 +372,7 @@ def is_unix_style(flags):
     )
 
 
-def translate(patterns, flags, pattern_limit=PATTERN_LIMIT):
+def translate(patterns, flags, limit=PATTERN_LIMIT):
     """Translate patterns."""
 
     positive = []
@@ -387,8 +387,8 @@ def translate(patterns, flags, pattern_limit=PATTERN_LIMIT):
 
     for pattern in patterns:
         for expanded in expand(util.norm_pattern(pattern, not is_unix, flags & RAWCHARS), flags):
-            if 0 <= pattern_limit < count:
-                raise PatternLimitException("Pattern limit exceeded the limit of {:d}".format(pattern_limit))
+            if 0 < limit < count:
+                raise PatternLimitException("Pattern limit exceeded the limit of {:d}".format(limit))
             if expanded in seen:
                 count += 1
                 continue
@@ -418,7 +418,7 @@ def split(pattern, flags):
         yield pattern
 
 
-def compile(patterns, flags, pattern_limit=PATTERN_LIMIT):  # noqa A001
+def compile(patterns, flags, limit=PATTERN_LIMIT):  # noqa A001
     """Compile patterns."""
 
     positive = []
@@ -432,8 +432,8 @@ def compile(patterns, flags, pattern_limit=PATTERN_LIMIT):  # noqa A001
 
     for pattern in patterns:
         for expanded in expand(util.norm_pattern(pattern, not is_unix, flags & RAWCHARS), flags):
-            if 0 <= pattern_limit < count:
-                raise PatternLimitException("Pattern limit exceeded the limit of {:d}".format(pattern_limit))
+            if 0 < limit < count:
+                raise PatternLimitException("Pattern limit exceeded the limit of {:d}".format(limit))
             if expanded in seen:
                 count += 1
                 continue

--- a/wcmatch/fnmatch.py
+++ b/wcmatch/fnmatch.py
@@ -69,14 +69,14 @@ def _flag_transform(flags):
     return (flags & FLAG_MASK)
 
 
-def translate(patterns, *, flags=0):
+def translate(patterns, *, flags=0, pattern_limit=_wcparse.PATTERN_LIMIT):
     """Translate `fnmatch` pattern."""
 
     flags = _flag_transform(flags)
-    return _wcparse.translate(patterns, flags)
+    return _wcparse.translate(patterns, flags, pattern_limit)
 
 
-def fnmatch(filename, patterns, *, flags=0):
+def fnmatch(filename, patterns, *, flags=0, pattern_limit=_wcparse.PATTERN_LIMIT):
     """
     Check if filename matches pattern.
 
@@ -87,17 +87,17 @@ def fnmatch(filename, patterns, *, flags=0):
     flags = _flag_transform(flags)
     if not _wcparse.is_unix_style(flags):
         filename = _wcparse.norm_slash(filename, flags)
-    return _wcparse.compile(patterns, flags).match(filename)
+    return _wcparse.compile(patterns, flags, pattern_limit).match(filename)
 
 
-def filter(filenames, patterns, *, flags=0):  # noqa A001
+def filter(filenames, patterns, *, flags=0, pattern_limit=_wcparse.PATTERN_LIMIT):  # noqa A001
     """Filter names using pattern."""
 
     matches = []
 
     flags = _flag_transform(flags)
     unix = _wcparse.is_unix_style(flags)
-    obj = _wcparse.compile(patterns, flags)
+    obj = _wcparse.compile(patterns, flags, pattern_limit)
 
     for filename in filenames:
         if obj.match(_wcparse.norm_slash(filename, flags) if not unix else filename):

--- a/wcmatch/fnmatch.py
+++ b/wcmatch/fnmatch.py
@@ -69,14 +69,14 @@ def _flag_transform(flags):
     return (flags & FLAG_MASK)
 
 
-def translate(patterns, *, flags=0, pattern_limit=_wcparse.PATTERN_LIMIT):
+def translate(patterns, *, flags=0, limit=_wcparse.PATTERN_LIMIT):
     """Translate `fnmatch` pattern."""
 
     flags = _flag_transform(flags)
-    return _wcparse.translate(patterns, flags, pattern_limit)
+    return _wcparse.translate(patterns, flags, limit)
 
 
-def fnmatch(filename, patterns, *, flags=0, pattern_limit=_wcparse.PATTERN_LIMIT):
+def fnmatch(filename, patterns, *, flags=0, limit=_wcparse.PATTERN_LIMIT):
     """
     Check if filename matches pattern.
 
@@ -87,17 +87,17 @@ def fnmatch(filename, patterns, *, flags=0, pattern_limit=_wcparse.PATTERN_LIMIT
     flags = _flag_transform(flags)
     if not _wcparse.is_unix_style(flags):
         filename = _wcparse.norm_slash(filename, flags)
-    return _wcparse.compile(patterns, flags, pattern_limit).match(filename)
+    return _wcparse.compile(patterns, flags, limit).match(filename)
 
 
-def filter(filenames, patterns, *, flags=0, pattern_limit=_wcparse.PATTERN_LIMIT):  # noqa A001
+def filter(filenames, patterns, *, flags=0, limit=_wcparse.PATTERN_LIMIT):  # noqa A001
     """Filter names using pattern."""
 
     matches = []
 
     flags = _flag_transform(flags)
     unix = _wcparse.is_unix_style(flags)
-    obj = _wcparse.compile(patterns, flags, pattern_limit)
+    obj = _wcparse.compile(patterns, flags, limit)
 
     for filename in filenames:
         if obj.match(_wcparse.norm_slash(filename, flags) if not unix else filename):

--- a/wcmatch/glob.py
+++ b/wcmatch/glob.py
@@ -165,7 +165,7 @@ class Glob(object):
                 if not self.nounique or is_neg:
                     if expanded in seen:
                         continue
-                    seen.add(p)
+                    seen.add(expanded)
 
                 yield is_neg, expanded
                 count += 1
@@ -176,8 +176,6 @@ class Glob(object):
         self.pattern = []
         self.npatterns = []
         nflags = self.flags | _wcparse.REALPATH
-        if nflags & _wcparse.NOUNIQUE:
-            nflags ^= _wcparse.NOUNIQUE
         for is_neg, p in self._iter_patterns(patterns):
             if is_neg:
                 # Treat the inverse pattern as a normal pattern if it matches, we will exclude.

--- a/wcmatch/glob.py
+++ b/wcmatch/glob.py
@@ -23,7 +23,6 @@ IN THE SOFTWARE.
 import os
 import sys
 import functools
-import re
 from . import _wcparse
 from . import util
 

--- a/wcmatch/glob.py
+++ b/wcmatch/glob.py
@@ -359,20 +359,13 @@ class Glob(object):
         if is_magic and is_globstar:
             # Glob star directory `**`.
 
-            # Throw away multiple consecutive `globstars`
-            # and acquire the pattern after the `globstars` if available.
+            # Acquire the pattern after the `globstars` if available.
+            # If not, mark that the `globstar` is the end.
             this = rest.pop(0) if rest else None
             globstar_end = this is None
-            while this and not globstar_end:
-                if this:
-                    dir_only = this.dir_only
-                    target = this.pattern
-                if this and this.is_globstar:
-                    this = rest.pop(0) if rest else None
-                    if this is None:
-                        globstar_end = True
-                else:
-                    break
+            if this:
+                dir_only = this.dir_only
+                target = this.pattern
 
             if globstar_end:
                 target = None

--- a/wcmatch/glob.py
+++ b/wcmatch/glob.py
@@ -151,12 +151,12 @@ class Glob(object):
 
         count = 1
         for p in patterns:
-            if 0 <= self.pattern_limit < count:
-                raise _wcparse.PatternLimitException(
-                    "Pattern limit exceeded the limit of {:d}".format(self.pattern_limit)
-                )
             p = util.norm_pattern(p, not self.unix, self.raw_chars)
             for expanded in _wcparse.expand(p, self.flags):
+                if 0 <= self.pattern_limit < count:
+                    raise _wcparse.PatternLimitException(
+                        "Pattern limit exceeded the limit of {:d}".format(self.pattern_limit)
+                    )
                 yield expanded
                 count += 1
 

--- a/wcmatch/pathlib.py
+++ b/wcmatch/pathlib.py
@@ -153,9 +153,6 @@ class PurePath(pathlib.PurePath):
 
         """
 
-        if flags & NOUNIQUE:
-            flags ^= NOUNIQUE
-
         return glob.globmatch(
             self._translate_path(),
             patterns,

--- a/wcmatch/pathlib.py
+++ b/wcmatch/pathlib.py
@@ -7,8 +7,8 @@ from . import _wcparse
 __all__ = (
     "CASE", "IGNORECASE", "RAWCHARS", "DOTGLOB", "DOTMATCH",
     "EXTGLOB", "EXTMATCH", "NEGATE", "MINUSNEGATE", "BRACE",
-    "REALPATH", "FOLLOW", "MATCHBASE", "NEGATEALL", "NODIR",
-    "C", "I", "R", "D", "E", "G", "N", "B", "M", "P", "L", "S", "X", "O", "A",
+    "REALPATH", "FOLLOW", "MATCHBASE", "NEGATEALL", "NODIR", "NOUNIQUE",
+    "C", "I", "R", "D", "E", "G", "N", "B", "M", "P", "L", "S", "X", "O", "A", "Q",
     "Path", "PurePath", "WindowsPath", "PosixPath", "PurePosixPath", "PureWindowsPath"
 )
 
@@ -27,6 +27,7 @@ S = SPLIT = glob.SPLIT
 X = MATCHBASE = glob.MATCHBASE
 O = NODIR = glob.NODIR
 A = NEGATEALL = glob.NEGATEALL
+Q = NOUNIQUE = glob.NOUNIQUE
 
 FLAG_MASK = (
     CASE |
@@ -44,6 +45,7 @@ FLAG_MASK = (
     MATCHBASE |
     NODIR |
     NEGATEALL |
+    NOUNIQUE |
     _wcparse._RECURSIVEMATCH |
     _wcparse._NOABSOLUTE
 )
@@ -141,11 +143,7 @@ class PurePath(pathlib.PurePath):
 
         """
 
-        return glob.globmatch(
-            self._translate_path(),
-            patterns,
-            flags=self._translate_flags(flags | _wcparse._RECURSIVEMATCH)
-        )
+        return self.globmatch(patterns, flags=flags | _wcparse._RECURSIVEMATCH)
 
     def globmatch(self, patterns, *, flags=0):
         """
@@ -154,6 +152,9 @@ class PurePath(pathlib.PurePath):
         `GLOBSTAR` is enabled by default in order match the default behavior of `pathlib`.
 
         """
+
+        if flags & NOUNIQUE:
+            flags ^= NOUNIQUE
 
         return glob.globmatch(
             self._translate_path(),

--- a/wcmatch/pathlib.py
+++ b/wcmatch/pathlib.py
@@ -67,7 +67,7 @@ class Path(pathlib.Path):
         self._init()
         return self
 
-    def glob(self, patterns, *, flags=0):
+    def glob(self, patterns, *, flags=0, pattern_limit=_wcparse.PATTERN_LIMIT):
         """
         Search the file system.
 
@@ -77,10 +77,10 @@ class Path(pathlib.Path):
 
         if self.is_dir():
             flags = self._translate_flags(flags | _wcparse._NOABSOLUTE)
-            for filename in glob.iglob(patterns, flags=flags, root_dir=str(self)):
+            for filename in glob.iglob(patterns, flags=flags, root_dir=str(self), pattern_limit=pattern_limit):
                 yield self.joinpath(filename)
 
-    def rglob(self, patterns, *, flags=0):
+    def rglob(self, patterns, *, flags=0, pattern_limit=_wcparse.PATTERN_LIMIT):
         """
         Recursive glob.
 
@@ -91,7 +91,7 @@ class Path(pathlib.Path):
 
         """
 
-        yield from self.glob(patterns, flags=flags | _wcparse._RECURSIVEMATCH)
+        yield from self.glob(patterns, flags=flags | _wcparse._RECURSIVEMATCH, pattern_limit=pattern_limit)
 
 
 class PurePath(pathlib.PurePath):
@@ -132,7 +132,7 @@ class PurePath(pathlib.PurePath):
 
         return name + sep
 
-    def match(self, patterns, *, flags=0):
+    def match(self, patterns, *, flags=0, pattern_limit=_wcparse.PATTERN_LIMIT):
         """
         Match patterns using `globmatch`, but also using the same recursive logic that the default `pathlib` uses.
 
@@ -143,9 +143,9 @@ class PurePath(pathlib.PurePath):
 
         """
 
-        return self.globmatch(patterns, flags=flags | _wcparse._RECURSIVEMATCH)
+        return self.globmatch(patterns, flags=flags | _wcparse._RECURSIVEMATCH, pattern_limit=pattern_limit)
 
-    def globmatch(self, patterns, *, flags=0):
+    def globmatch(self, patterns, *, flags=0, pattern_limit=_wcparse.PATTERN_LIMIT):
         """
         Match patterns using `globmatch`, but without the recursive logic that the default `pathlib` uses.
 
@@ -159,7 +159,8 @@ class PurePath(pathlib.PurePath):
         return glob.globmatch(
             self._translate_path(),
             patterns,
-            flags=self._translate_flags(flags)
+            flags=self._translate_flags(flags),
+            pattern_limit=pattern_limit
         )
 
 

--- a/wcmatch/pathlib.py
+++ b/wcmatch/pathlib.py
@@ -67,7 +67,7 @@ class Path(pathlib.Path):
         self._init()
         return self
 
-    def glob(self, patterns, *, flags=0, pattern_limit=_wcparse.PATTERN_LIMIT):
+    def glob(self, patterns, *, flags=0, limit=_wcparse.PATTERN_LIMIT):
         """
         Search the file system.
 
@@ -77,10 +77,10 @@ class Path(pathlib.Path):
 
         if self.is_dir():
             flags = self._translate_flags(flags | _wcparse._NOABSOLUTE)
-            for filename in glob.iglob(patterns, flags=flags, root_dir=str(self), pattern_limit=pattern_limit):
+            for filename in glob.iglob(patterns, flags=flags, root_dir=str(self), limit=limit):
                 yield self.joinpath(filename)
 
-    def rglob(self, patterns, *, flags=0, pattern_limit=_wcparse.PATTERN_LIMIT):
+    def rglob(self, patterns, *, flags=0, limit=_wcparse.PATTERN_LIMIT):
         """
         Recursive glob.
 
@@ -91,7 +91,7 @@ class Path(pathlib.Path):
 
         """
 
-        yield from self.glob(patterns, flags=flags | _wcparse._RECURSIVEMATCH, pattern_limit=pattern_limit)
+        yield from self.glob(patterns, flags=flags | _wcparse._RECURSIVEMATCH, limit=limit)
 
 
 class PurePath(pathlib.PurePath):
@@ -132,7 +132,7 @@ class PurePath(pathlib.PurePath):
 
         return name + sep
 
-    def match(self, patterns, *, flags=0, pattern_limit=_wcparse.PATTERN_LIMIT):
+    def match(self, patterns, *, flags=0, limit=_wcparse.PATTERN_LIMIT):
         """
         Match patterns using `globmatch`, but also using the same recursive logic that the default `pathlib` uses.
 
@@ -143,9 +143,9 @@ class PurePath(pathlib.PurePath):
 
         """
 
-        return self.globmatch(patterns, flags=flags | _wcparse._RECURSIVEMATCH, pattern_limit=pattern_limit)
+        return self.globmatch(patterns, flags=flags | _wcparse._RECURSIVEMATCH, limit=limit)
 
-    def globmatch(self, patterns, *, flags=0, pattern_limit=_wcparse.PATTERN_LIMIT):
+    def globmatch(self, patterns, *, flags=0, limit=_wcparse.PATTERN_LIMIT):
         """
         Match patterns using `globmatch`, but without the recursive logic that the default `pathlib` uses.
 
@@ -157,7 +157,7 @@ class PurePath(pathlib.PurePath):
             self._translate_path(),
             patterns,
             flags=self._translate_flags(flags),
-            pattern_limit=pattern_limit
+            limit=limit
         )
 
 

--- a/wcmatch/wcmatch.py
+++ b/wcmatch/wcmatch.py
@@ -96,7 +96,7 @@ class WcMatch(object):
             )
         self.exclude_pattern = args.pop(0) if args else kwargs.pop('exclude_pattern', b'' if self.is_bytes else '')
         self._parse_flags(args.pop(0) if args else kwargs.pop('flags', 0))
-        self.pattern_limit = kwargs.pop('pattern_limit', _wcparse.PATTERN_LIMIT)
+        self.limit = kwargs.pop('limit', _wcparse.PATTERN_LIMIT)
         self.on_init(*args, **kwargs)
         self.file_check, self.folder_exclude_check = self._compile(self.file_pattern, self.exclude_pattern)
 
@@ -124,7 +124,7 @@ class WcMatch(object):
             if self.matchbase:
                 flags |= _wcparse.MATCHBASE
 
-        return _wcparse.compile(pattern, flags, self.pattern_limit) if pattern else None
+        return _wcparse.compile(pattern, flags, self.limit) if pattern else None
 
     def _compile(self, file_pattern, folder_exclude_pattern):
         """Compile patterns."""

--- a/wcmatch/wcmatch.py
+++ b/wcmatch/wcmatch.py
@@ -96,6 +96,7 @@ class WcMatch(object):
             )
         self.exclude_pattern = args.pop(0) if args else kwargs.pop('exclude_pattern', b'' if self.is_bytes else '')
         self._parse_flags(args.pop(0) if args else kwargs.pop('flags', 0))
+        self.pattern_limit = kwargs.pop('pattern_limit', _wcparse.PATTERN_LIMIT)
         self.on_init(*args, **kwargs)
         self.file_check, self.folder_exclude_check = self._compile(self.file_pattern, self.exclude_pattern)
 
@@ -123,7 +124,7 @@ class WcMatch(object):
             if self.matchbase:
                 flags |= _wcparse.MATCHBASE
 
-        return _wcparse.compile(pattern, flags) if pattern else None
+        return _wcparse.compile(pattern, flags, self.pattern_limit) if pattern else None
 
     def _compile(self, file_pattern, folder_exclude_pattern):
         """Compile patterns."""


### PR DESCRIPTION
- BRACE is now processed before SPLIT.
- We now optimize out duplicate patterns and reduce duplicate returns..
- We also now limit patterns to 1000. This includes patterns directly passed in, and patterns indirectly included via expansion by BRACE and/or SPLIT.
- Added new option NOUNIQUE to turn off the above "unique" pattern/result behavior above. Only affects glob, iglob, rglob functions.

Fixes #97
Fixes #99 