### PR TITLE
Experimental: No special dirs are returned with pathlib magic patterns

### DIFF
--- a/wcmatch/__meta__.py
+++ b/wcmatch/__meta__.py
@@ -186,5 +186,5 @@ def parse_version(ver, pre=False):
     return Version(major, minor, micro, release, pre, post, dev)
 
 
-__version_info__ = Version(6, 0, 2, ".dev")
+__version_info__ = Version(6, 1, 0, ".dev")
 __version__ = __version_info__._get_canonical()

--- a/wcmatch/pathlib.py
+++ b/wcmatch/pathlib.py
@@ -76,7 +76,7 @@ class Path(pathlib.Path):
         """
 
         if self.is_dir():
-            flags = self._translate_flags(flags | _wcparse._NOABSOLUTE)
+            flags = self._translate_flags(flags | _wcparse._NOABSOLUTE) | glob._NOSPECIAL
             for filename in glob.iglob(patterns, flags=flags, root_dir=str(self), limit=limit):
                 yield self.joinpath(filename)
 


### PR DESCRIPTION
This would help avoid confusion as Pathlib will normalize directories
such as `folder/.` to `folder` and causes a lot of confusion.

@gir-bot add S: work-in-progress