### PR TITLE
Fix pathlib match behavior related to dot files

### DIFF
--- a/docs/src/dictionary/en-custom.txt
+++ b/docs/src/dictionary/en-custom.txt
@@ -51,6 +51,7 @@ pathlike
 posix
 pre
 prepend
+prepends
 preprocessing
 preprocessors
 prerelease
@@ -64,6 +65,7 @@ subclasses
 subdirectories
 sublicense
 symlink
+symlinked
 symlinks
 syntaxes
 tuple

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -2,12 +2,14 @@
 
 ## 6.0.3
 
-- **FIX**: Fix fix issue with `FOLLOW` and `GLOBSTAR`.
-- **FIX**: When using `wcmatch.pathlib` we were not fully emulating Python's `match` behavior. Python's version
-  evaluates the path from right to left, so dot files on the left will not prevent a match if the pattern does not force
-  them to be evaluated. We now properly emulate this behavior and should properly match right most file names regardless
-  of dot files on the left (as required by the given pattern). This means `.hidden/file` path should be matched by the
-  pattern `file` even if `DOTGLOB` is not enabled.
+- **FIX**: Fix fix issue where when `FOLLOW` and `GLOBSTAR` was used, a pattern like `**/*` would not properly match
+  a directory which was a symlink. While Bash does not return a symlinked folder with `**`, `*` (and other patterns),
+  should properly find the symlinked directory.
+- **FIX**: `pathlib` clearly states that the `match` method, if the pattern is relative, matches from the right.
+  Wildcard Match used the same implementation that `rglob` used, which prepends `**/` to a relative pattern. This is
+  essentially like `MATCHBASE`, but allows for multiple directory levels. This means that dot files (and special folders
+  such as `.` and `..`) on the left side could prevent the path from matching depending on flags that were set. `match`
+  will now be evaluated in such a way as to give the same right to left matching feel that Python's `pathlib` uses.
 
 ## 6.0.2
 

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -3,6 +3,11 @@
 ## 6.0.3
 
 - **FIX**: Fix fix issue with `FOLLOW` and `GLOBSTAR`.
+- **FIX**: When using `wcmatch.pathlib` we were not fully emulating Python's `match` behavior. Python's version
+  evaluates the path from right to left, so dot files on the left will not prevent a match if the pattern does not force
+  them to be evaluated. We now properly emulate this behavior and should properly match right most file names regardless
+  of dot files on the left (as required by the given pattern). This means `.hidden/file` path should be matched by the
+  pattern `file` even if `DOTGLOB` is not enabled.
 
 ## 6.0.2
 

--- a/docs/src/markdown/glob.md
+++ b/docs/src/markdown/glob.md
@@ -736,7 +736,9 @@ enabled, ensuring the files have trailing slashes can still save you a call to `
 
 `MATCHBASE`, when a pattern has no slashes in it, will cause [`glob`](#globglob) and [`iglob`](#globiglob) to seek for
 any file anywhere in the tree with a matching basename. When enabled for [`globfilter`](#globglobfilter) and
-[`globmatch`](#globglobmatch), any path whose basename matches.
+[`globmatch`](#globglobmatch), any path whose basename matches. `MATCHBASE` is sensitive to files and directories that
+start with `.` and will not match such files and directories if [`DOTGLOB`](#globdotglob) is not enabled.
+
 
 ```pycon3
 >>> from wcmatch import glob

--- a/docs/src/markdown/pathlib.md
+++ b/docs/src/markdown/pathlib.md
@@ -217,13 +217,22 @@ def match(self, patterns, *, flags=0, limit=1000):
 ```
 
 `match` takes a pattern (or list of patterns), and flags.  It also allows configuring the [max pattern
-limit](#multi-pattern-limits). It will return a boolean indicating whether the objects file path was matched by the
+limit](#multi-pattern-limits). It will return a boolean indicating whether the object's file path was matched by the
 pattern(s).
 
-`match` mimics Python's `pathlib` version of `match` in that it uses a recursive logic. What this means is when you are
-matching a path in the form `some/path/name`, the patterns `name`, `path/name` and `some/path/name` will all match.
-Essentially, the pattern, if not an absolute pattern, behaves as if a [`GLOBSTAR`](#pathlibglobstar) pattern of `**/`
-was added at the beginning of the pattern.
+`match` mimics Python's `pathlib` version of `match`. Python's `match` uses a right to left evaluation. Wildcard Match
+emulates this behavior as well. What this means is that when provided with a path `some/path/name`, the patterns `name`,
+`path/name` and `some/path/name` will all match.
+
+Because the path is evaluated right to left, dot files may not prevent matches when `DOTGLOB` is disabled.
+
+```pycon3
+>>> from wcmatch import pathlib
+>>> pathlib.PurePath('.dotfile/file').match('file')
+True
+>>> pathlib.PurePath('../.dotfile/file').match('file')
+True
+```
 
 `match` does not access the filesystem, but you can force the path to access the filesystem if you give it the
 [`REALPATH`](#pathlibrealpath) flag. We do not restrict this, but we do not enable it by default.
@@ -516,7 +525,8 @@ benefit from disabling "unique" optimizations, they would only run slower, so `N
 
 `MATCHBASE`, when a pattern has no slashes in it, will cause all glob related functions to seek for any file anywhere in
 the tree with a matching basename, or in the case of [`match`](#purepathmatch) and [`globmatch`](#purepathglobmatch),
-path whose basename matches.
+path whose basename matches. `MATCHBASE` is sensitive to files and directories that start with `.` and will not match
+such files and directories if [`DOTGLOB`](#pathlibdotglob) is not enabled.
 
 ```pycon3
 >>> from wcmatch import pathlib

--- a/docs/src/markdown/wcmatch.md
+++ b/docs/src/markdown/wcmatch.md
@@ -387,7 +387,7 @@ folder was `.`, and the folder under evaluation is `./some/folder`, `some/folder
 
 ```pycon3
 >>> from wcmatch import wcmatch
->>> wcmatch.WcMatch('.', '*.md|*.txt', 'docs/src/markdown', recursive=True, flags=wcmatch.DIRPATHNAME).match()
+>>> wcmatch.WcMatch('.', '*.md|*.txt', 'docs/src/markdown', flags=wcmatch.DIRPATHNAME | wcmatch.RECURSIVE).match()
 ['./LICENSE.md', './README.md', './requirements/docs.txt', './requirements/lint.txt', './requirements/setup.txt', './requirements/test.txt']
 ```
 
@@ -399,7 +399,7 @@ patterns. The path name compared will be the entire path relative to the base pa
 
 ```pycon3
 >>> from wcmatch import wcmatch
->>> wcmatch.WcMatch('.', '**/*.md|!**/_snippets/*', recursive=True, flags=wcmatch.FILEPATHNAME | wcmatch.GLOBSTAR).match()
+>>> wcmatch.WcMatch('.', '**/*.md|!**/_snippets/*', flags=wcmatch.FILEPATHNAME | wcmatch.GLOBSTAR | wcmatch.RECURSIVE).match()
 ['./LICENSE.md', './README.md', './docs/src/markdown/changelog.md', './docs/src/markdown/fnmatch.md', './docs/src/markdown/glob.md', './docs/src/markdown/index.md', './docs/src/markdown/license.md', './docs/src/markdown/wcmatch.md']
 ```
 
@@ -445,7 +445,7 @@ directory pattern matches with `**`.
 
 ```pycon3
 >>> from wcmatch import wcmatch
->>> wcmatch.WcMatch('.', '*.md|*.txt', '**/markdown', recursive=True, flags=wcmatch.DIRPATHNAME | wcmatch.GLOBSTAR).match()
+>>> wcmatch.WcMatch('.', '*.md|*.txt', '**/markdown', flags=wcmatch.DIRPATHNAME | wcmatch.GLOBSTAR | wcmatch.RECURSIVE).match()
 ['./LICENSE.md', './README.md', './requirements/docs.txt', './requirements/lint.txt', './requirements/setup.txt', './requirements/test.txt']
 ```
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,7 +41,7 @@ markdown_extensions:
   - markdown.extensions.tables:
   - markdown.extensions.abbr:
   - markdown.extensions.footnotes:
-  - pymdownx.extrarawhtml:
+  - markdown.extensions.md_in_html:
   - pymdownx.superfences:
       preserve_tabs: true
   - pymdownx.highlight:

--- a/wcmatch/fnmatch.py
+++ b/wcmatch/fnmatch.py
@@ -63,8 +63,8 @@ def _flag_transform(flags):
     """Transform flags to glob defaults."""
 
     # Enabling both cancels out
-    if flags & _wcparse.FORCEUNIX and flags & _wcparse.FORCEWIN:
-        flags ^= _wcparse.FORCEWIN | _wcparse.FORCEUNIX
+    if flags & FORCEUNIX and flags & FORCEWIN:
+        flags ^= FORCEWIN | FORCEUNIX
 
     return (flags & FLAG_MASK)
 

--- a/wcmatch/glob.py
+++ b/wcmatch/glob.py
@@ -61,6 +61,12 @@ Q = NOUNIQUE = _wcparse.NOUNIQUE
 
 K = MARK = 0x100000
 
+# Internal flags
+_EXTMATCHBASE = _wcparse._EXTMATCHBASE
+_RTL = _wcparse._RTL
+_NOABSOLUTE = _wcparse._NOABSOLUTE
+_PATHNAME = _wcparse.PATHNAME
+
 FLAG_MASK = (
     CASE |
     IGNORECASE |
@@ -81,9 +87,9 @@ FLAG_MASK = (
     FORCEUNIX |
     GLOBTILDE |
     NOUNIQUE |
-    _wcparse._EXTMATCHBASE |
-    _wcparse._RTL |
-    _wcparse._NOABSOLUTE
+    _EXTMATCHBASE |
+    _RTL |
+    _NOABSOLUTE
 )
 
 
@@ -91,19 +97,19 @@ def _flag_transform(flags):
     """Transform flags to glob defaults."""
 
     # Enabling both cancels out
-    if flags & _wcparse.FORCEUNIX and flags & _wcparse.FORCEWIN:
-        flags ^= _wcparse.FORCEWIN | _wcparse.FORCEUNIX
+    if flags & FORCEUNIX and flags & FORCEWIN:
+        flags ^= FORCEWIN | FORCEUNIX
 
     # Here we force `PATHNAME`.
-    flags = (flags & FLAG_MASK) | _wcparse.PATHNAME
-    if flags & _wcparse.REALPATH:
+    flags = (flags & FLAG_MASK) | _PATHNAME
+    if flags & REALPATH:
         if util.platform() == "windows":
-            if flags & _wcparse.FORCEUNIX:
-                flags ^= _wcparse.FORCEUNIX
-            flags |= _wcparse.FORCEWIN
+            if flags & FORCEUNIX:
+                flags ^= FORCEUNIX
+            flags |= FORCEWIN
         else:
-            if flags & _wcparse.FORCEWIN:
-                flags ^= _wcparse.FORCEWIN
+            if flags & FORCEWIN:
+                flags ^= FORCEWIN
 
     return flags
 
@@ -125,27 +131,27 @@ class Glob(object):
         self.negateall = bool(flags & NEGATEALL)
         if self.negateall:
             flags ^= NEGATEALL
-        self.nodir = bool(flags & _wcparse.NODIR)
+        self.nodir = bool(flags & NODIR)
         if self.nodir:
-            flags ^= _wcparse.NODIR
+            flags ^= NODIR
         # Right to left searching is only for matching
-        if flags & _wcparse._RTL:  # pragma: no cover
-            flags ^= _wcparse._RTL
-        self.flags = _flag_transform(flags | _wcparse.REALPATH)
+        if flags & _RTL:  # pragma: no cover
+            flags ^= _RTL
+        self.flags = _flag_transform(flags | REALPATH)
         self.raw_chars = bool(self.flags & RAWCHARS)
         self.follow_links = bool(self.flags & FOLLOW)
         self.dot = bool(self.flags & DOTMATCH)
-        self.unix = not bool(self.flags & _wcparse.FORCEWIN)
+        self.unix = not bool(self.flags & FORCEWIN)
         self.negate = bool(self.flags & NEGATE)
-        self.globstar = bool(self.flags & _wcparse.GLOBSTAR)
-        self.braces = bool(self.flags & _wcparse.BRACE)
-        self.matchbase = bool(self.flags & _wcparse.MATCHBASE)
+        self.globstar = bool(self.flags & GLOBSTAR)
+        self.braces = bool(self.flags & BRACE)
+        self.matchbase = bool(self.flags & MATCHBASE)
         self.case_sensitive = _wcparse.get_case(self.flags)
         self.specials = (b'.', b'..') if self.is_bytes else ('.', '..')
         self.empty = b'' if self.is_bytes else ''
         self.limit = limit
         self._parse_patterns(pattern)
-        if self.flags & _wcparse.FORCEWIN:
+        if self.flags & FORCEWIN:
             self.sep = b'\\' if self.is_bytes else '\\'
         else:
             self.sep = b'/' if self.is_bytes else '/'
@@ -179,7 +185,7 @@ class Glob(object):
 
         self.pattern = []
         self.npatterns = []
-        nflags = self.flags | _wcparse.REALPATH
+        nflags = self.flags | REALPATH
         for is_neg, p in self._iter_patterns(patterns):
             if is_neg:
                 # Treat the inverse pattern as a normal pattern if it matches, we will exclude.
@@ -198,7 +204,7 @@ class Glob(object):
 
         if self.nodir:
             ptype = _wcparse.BYTES if self.is_bytes else _wcparse.UNICODE
-            nodir = _wcparse.RE_WIN_NO_DIR[ptype] if self.flags & _wcparse.FORCEWIN else _wcparse.RE_NO_DIR[ptype]
+            nodir = _wcparse.RE_WIN_NO_DIR[ptype] if self.flags & FORCEWIN else _wcparse.RE_NO_DIR[ptype]
             self.npatterns.append(nodir)
 
         # A single positive pattern will not find multiples of the same file

--- a/wcmatch/glob.py
+++ b/wcmatch/glob.py
@@ -81,7 +81,8 @@ FLAG_MASK = (
     FORCEUNIX |
     GLOBTILDE |
     NOUNIQUE |
-    _wcparse._RECURSIVEMATCH |
+    _wcparse._EXTMATCHBASE |
+    _wcparse._RTL |
     _wcparse._NOABSOLUTE
 )
 
@@ -117,8 +118,8 @@ class Glob(object):
         self.is_bytes = isinstance(pattern[0], bytes)
         self.current = b'.' if self.is_bytes else '.'
         self.root_dir = util.fscodec(root_dir, self.is_bytes) if root_dir is not None else self.current
-        self.mark = bool(flags & MARK)
         self.nounique = bool(flags & NOUNIQUE)
+        self.mark = bool(flags & MARK)
         if self.mark:
             flags ^= MARK
         self.negateall = bool(flags & NEGATEALL)
@@ -127,6 +128,9 @@ class Glob(object):
         self.nodir = bool(flags & _wcparse.NODIR)
         if self.nodir:
             flags ^= _wcparse.NODIR
+        # Right to left searching is only for matching
+        if flags & _wcparse._RTL:  # pragma: no cover
+            flags ^= _wcparse._RTL
         self.flags = _flag_transform(flags | _wcparse.REALPATH)
         self.raw_chars = bool(self.flags & RAWCHARS)
         self.follow_links = bool(self.flags & FOLLOW)

--- a/wcmatch/pathlib.py
+++ b/wcmatch/pathlib.py
@@ -29,6 +29,14 @@ O = NODIR = glob.NODIR
 A = NEGATEALL = glob.NEGATEALL
 Q = NOUNIQUE = glob.NOUNIQUE
 
+# Internal flags
+_EXTMATCHBASE = _wcparse._EXTMATCHBASE
+_RTL = _wcparse._RTL
+_NOABSOLUTE = _wcparse._NOABSOLUTE
+_PATHNAME = _wcparse.PATHNAME
+_FORCEWIN = _wcparse.FORCEWIN
+_FORCEUNIX = _wcparse.FORCEUNIX
+
 FLAG_MASK = (
     CASE |
     IGNORECASE |
@@ -46,9 +54,9 @@ FLAG_MASK = (
     NODIR |
     NEGATEALL |
     NOUNIQUE |
-    _wcparse._EXTMATCHBASE |
-    _wcparse._RTL |
-    _wcparse._NOABSOLUTE
+    _EXTMATCHBASE |
+    _RTL |
+    _NOABSOLUTE
 )
 
 
@@ -77,7 +85,7 @@ class Path(pathlib.Path):
         """
 
         if self.is_dir():
-            flags = self._translate_flags(flags | _wcparse._NOABSOLUTE)
+            flags = self._translate_flags(flags | _NOABSOLUTE)
             for filename in glob.iglob(patterns, flags=flags, root_dir=str(self), limit=limit):
                 yield self.joinpath(filename)
 
@@ -92,7 +100,7 @@ class Path(pathlib.Path):
 
         """
 
-        yield from self.glob(patterns, flags=flags | _wcparse._EXTMATCHBASE, limit=limit)
+        yield from self.glob(patterns, flags=flags | _EXTMATCHBASE, limit=limit)
 
 
 class PurePath(pathlib.PurePath):
@@ -110,17 +118,17 @@ class PurePath(pathlib.PurePath):
     def _translate_flags(self, flags):
         """Translate flags for the current `pathlib` object."""
 
-        flags = (flags & FLAG_MASK) | _wcparse.PATHNAME
+        flags = (flags & FLAG_MASK) | _PATHNAME
         if flags & REALPATH:
-            flags |= _wcparse.FORCEWIN if os.name == 'nt' else _wcparse.FORCEUNIX
+            flags |= _FORCEWIN if os.name == 'nt' else _FORCEUNIX
         if isinstance(self, PureWindowsPath):
-            if flags & _wcparse.FORCEUNIX:
+            if flags & _FORCEUNIX:
                 raise ValueError("Windows pathlike objects cannot be forced to behave like a Posix path")
-            flags |= _wcparse.FORCEWIN
+            flags |= _FORCEWIN
         elif isinstance(self, PurePosixPath):
-            if flags & _wcparse.FORCEWIN:
+            if flags & _FORCEWIN:
                 raise ValueError("Posix pathlike objects cannot be forced to behave like a Windows path")
-            flags |= _wcparse.FORCEUNIX
+            flags |= _FORCEUNIX
         return flags
 
     def _translate_path(self):
@@ -144,7 +152,7 @@ class PurePath(pathlib.PurePath):
 
         """
 
-        return self.globmatch(patterns, flags=flags | _wcparse._RTL, limit=limit)
+        return self.globmatch(patterns, flags=flags | _RTL, limit=limit)
 
     def globmatch(self, patterns, *, flags=0, limit=_wcparse.PATTERN_LIMIT):
         """

--- a/wcmatch/pathlib.py
+++ b/wcmatch/pathlib.py
@@ -46,7 +46,8 @@ FLAG_MASK = (
     NODIR |
     NEGATEALL |
     NOUNIQUE |
-    _wcparse._RECURSIVEMATCH |
+    _wcparse._EXTMATCHBASE |
+    _wcparse._RTL |
     _wcparse._NOABSOLUTE
 )
 
@@ -91,7 +92,7 @@ class Path(pathlib.Path):
 
         """
 
-        yield from self.glob(patterns, flags=flags | _wcparse._RECURSIVEMATCH, limit=limit)
+        yield from self.glob(patterns, flags=flags | _wcparse._EXTMATCHBASE, limit=limit)
 
 
 class PurePath(pathlib.PurePath):
@@ -134,20 +135,20 @@ class PurePath(pathlib.PurePath):
 
     def match(self, patterns, *, flags=0, limit=_wcparse.PATTERN_LIMIT):
         """
-        Match patterns using `globmatch`, but also using the same recursive logic that the default `pathlib` uses.
+        Match patterns using `globmatch`, but also using the same right to left logic that the default `pathlib` uses.
 
-        This uses the same recursive logic that the default `pathlib` object uses.
+        This uses the same right to left logic that the default `pathlib` object uses.
         Folders and files are essentially matched from right to left.
 
         `GLOBSTAR` is enabled by default in order match the default behavior of `pathlib`.
 
         """
 
-        return self.globmatch(patterns, flags=flags | _wcparse._RECURSIVEMATCH, limit=limit)
+        return self.globmatch(patterns, flags=flags | _wcparse._RTL, limit=limit)
 
     def globmatch(self, patterns, *, flags=0, limit=_wcparse.PATTERN_LIMIT):
         """
-        Match patterns using `globmatch`, but without the recursive logic that the default `pathlib` uses.
+        Match patterns using `globmatch`, but without the right to left logic that the default `pathlib` uses.
 
         `GLOBSTAR` is enabled by default in order match the default behavior of `pathlib`.
 

--- a/wcmatch/wcmatch.py
+++ b/wcmatch/wcmatch.py
@@ -26,7 +26,7 @@ from . import _wcparse
 from . import util
 
 __all__ = (
-    "CASE", "IGNORECASE", "RAWCHARS", "FILEPATHNAME", "DIRPATHNAME",
+    "CASE", "IGNORECASE", "RAWCHARS", "FILEPATHNAME", "DIRPATHNAME", "PATHNAME",
     "EXTMATCH", "GLOBSTAR", "BRACE", "MINUSNEGATE", "SYMLINKS", "HIDDEN", "RECURSIVE",
     "MATCHBASE",
     "C", "I", "R", "P", "E", "G", "M", "DP", "FP", "SL", "HD", "RV", "X", "B",
@@ -48,6 +48,15 @@ FP = FILEPATHNAME = 0x200000
 SL = SYMLINKS = 0x400000
 HD = HIDDEN = 0x800000
 RV = RECURSIVE = 0x1000000
+
+# Internal flags
+_ANCHOR = _wcparse._ANCHOR
+_NEGATE = _wcparse.NEGATE
+_DOTMATCH = _wcparse.DOTMATCH
+_NEGATEALL = _wcparse.NEGATEALL
+_SPLIT = _wcparse.SPLIT
+_FORCEWIN = _wcparse.FORCEWIN
+_PATHNAME = _wcparse.PATHNAME
 
 # Control `PATHNAME` for file and folder
 P = PATHNAME = DIRPATHNAME | FILEPATHNAME
@@ -104,7 +113,7 @@ class WcMatch(object):
         """Parse flags."""
 
         self.flags = flags & FLAG_MASK
-        self.flags |= _wcparse.NEGATE | _wcparse.DOTMATCH | _wcparse.NEGATEALL | _wcparse.SPLIT
+        self.flags |= _NEGATE | _DOTMATCH | _NEGATEALL | _SPLIT
         self.follow_links = bool(self.flags & SYMLINKS)
         self.show_hidden = bool(self.flags & HIDDEN)
         self.recursive = bool(self.flags & RECURSIVE)
@@ -112,7 +121,7 @@ class WcMatch(object):
         self.file_pathname = bool(self.flags & FILEPATHNAME)
         self.matchbase = bool(self.flags & MATCHBASE)
         if util.platform() == "windows":
-            self.flags |= _wcparse.FORCEWIN
+            self.flags |= _FORCEWIN
         self.flags = self.flags & (_wcparse.FLAG_MASK ^ MATCHBASE)
 
     def _compile_wildcard(self, pattern, pathname=False):
@@ -120,9 +129,9 @@ class WcMatch(object):
 
         flags = self.flags
         if pathname:
-            flags |= _wcparse.PATHNAME | _wcparse._ANCHOR
+            flags |= _PATHNAME | _ANCHOR
             if self.matchbase:
-                flags |= _wcparse.MATCHBASE
+                flags |= MATCHBASE
 
         return _wcparse.compile(pattern, flags, self.limit) if pattern else None
 


### PR DESCRIPTION
Pathlib should not be limited by dotfiles on the left as evaluation
order is from right to left.