### PR TITLE
Glob should match Bash 5.0 behavior in regard to link following

### DIFF
--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 6.0.3
+
+- **FIX**: Fix fix issue with `FOLLOW` and `GLOBSTAR`.
+
 ## 6.0.2
 
 - **FIX**: Fix logic related to dot files and `GLOBSTAR`. Recursive directory search should return all dot files, which

--- a/tests/test_glob.py
+++ b/tests/test_glob.py
@@ -401,6 +401,33 @@ class Testglob(_TestGlob):
         # Glob with braces and "unique" turned off
         [('{a*,a*}',), [('a',), ('aab',), ('aaa',), ('a',), ('aab',), ('aaa',)], glob.Q],
 
+        # Test recursive glob logic with no symlink following.
+        [
+            ('**', '*'),
+            [
+                ('aab',), ('aab', 'F'), ('a',), ('a', 'bcd'), ('a', 'bcd', 'EF'), ('a', 'bcd', 'efg'),
+                ('a', 'bcd', 'efg', 'ha'), ('a', 'D'), ('aaa',), ('aaa', 'zzzF'), ('EF',), ('ZZZ',)
+            ] if not can_symlink() else [
+                ('aab',), ('aab', 'F'), ('a',), ('a', 'bcd'), ('a', 'bcd', 'EF'), ('a', 'bcd', 'efg'),
+                ('a', 'bcd', 'efg', 'ha'), ('a', 'D'), ('aaa',), ('aaa', 'zzzF'), ('EF',), ('ZZZ',),
+                ('sym1',), ('sym2',), ('sym3',)
+            ],
+            glob.L
+        ],
+
+        [
+            ('**',),
+            [
+                ('',), ('aab',), ('aab', 'F'), ('a',), ('a', 'bcd'), ('a', 'bcd', 'EF'), ('a', 'bcd', 'efg'),
+                ('a', 'bcd', 'efg', 'ha'), ('a', 'D'), ('aaa',), ('aaa', 'zzzF'), ('EF',), ('ZZZ',)
+            ] if not can_symlink() else [
+                ('',), ('aab',), ('aab', 'F'), ('a',), ('a', 'bcd'), ('a', 'bcd', 'EF'), ('a', 'bcd', 'efg'),
+                ('a', 'bcd', 'efg', 'ha'), ('a', 'D'), ('aaa',), ('aaa', 'zzzF'), ('EF',), ('ZZZ',),
+                ('sym1',), ('sym2',)
+            ],
+            glob.L
+        ],
+
         Options(default_negate='**'),
         # Glob inverse
         [
@@ -455,7 +482,7 @@ class Testglob(_TestGlob):
             ] if not can_symlink() else [
                 ('EF',), ('ZZZ',), ('a',), ('a', 'D'), ('a', 'bcd'), ('a', 'bcd', 'EF'),
                 ('a', 'bcd', 'efg'), ('a', 'bcd', 'efg', 'ha'), ('aaa',), ('aaa', 'zzzF'), ('aab',),
-                ('aab', 'F'), ('sym1',), ('sym2',)
+                ('aab', 'F'), ('sym1',), ('sym2',), ('sym3',)
             ],
             glob.L | glob.X
         ],

--- a/wcmatch/__meta__.py
+++ b/wcmatch/__meta__.py
@@ -186,5 +186,5 @@ def parse_version(ver, pre=False):
     return Version(major, minor, micro, release, pre, post, dev)
 
 
-__version_info__ = Version(6, 0, 2, "final")
+__version_info__ = Version(6, 0, 3, ".dev")
 __version__ = __version_info__._get_canonical()


### PR DESCRIPTION
Doing some evaluation and noticed that `**` and `**/*` wasn't quite behaving correctly, but this was only with `glob` and not `globmatch`. Basically `**/*` was not matching a symlinked folder. This is because when we iterated through folders with `**`, we did not return symlinks to directories if `FOLLOW` was not enabled. So in case of `**/*` which should have matched the directory, but didn't.

Tests have been added to ensure this doesn't break in the future.