### PR TITLE
Basic handling of ! and !( at start of file path

### DIFF
--- a/docs/src/dictionary/en-custom.txt
+++ b/docs/src/dictionary/en-custom.txt
@@ -2,6 +2,7 @@ API
 Accessors
 Backport
 Changelog
+EXTGLOB
 EXTMATCH
 EmojiOne
 Fnmatch

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 6.1.0
+
+- **NEW**: `EXTMATCH`/`EXTGLOB` can now be used with `NEGATE` without needing `MINUSNEGATE`. If a pattern starts with
+  `!(`, the pattern will not be treated as a `NEGATE` pattern (even if `!(` doesn't yield a valid `EXTGLOB` pattern).
+  To negate a pattern that starts with a literal `(`, you must escape the bracket: `!\(`.
+
 ## 6.0.3
 
 - **FIX**: Fix issue where when `FOLLOW` and `GLOBSTAR` were used, a pattern like `**/*` would not properly match

--- a/docs/src/markdown/fnmatch.md
+++ b/docs/src/markdown/fnmatch.md
@@ -180,10 +180,6 @@ Assuming the `SPLIT` flag, this means using it in a pattern such as `inclusion|!
 If it is desired, you can force exclusion patterns, when no inclusion pattern is provided, to assume all files match
 unless the file matches the excluded pattern. This is done with the [`NEGATEALL`](#fnmatchnegateall) flag.
 
-If used with the extended match feature, patterns like `!(inverse|pattern)` will be mistakenly parsed as an exclusion
-pattern instead of as an inverse extended glob group.  See [`MINUSNEGATE`](#fnmatchminusgate) for an alternative syntax
-that plays nice with extended glob.
-
 !!! warning "Changes 4.0"
     In 4.0, `NEGATE` now requires a non-exclusion pattern to be paired with it or it will match nothing. If you really
     need something similar to the old behavior, that would assume a default inclusion pattern, you can use the
@@ -214,8 +210,10 @@ other character. Dots will not be matched in `[]`, `*`, or `?`.
 etc. See the [syntax overview](#syntax) for more information.
 
 !!! tip "EXTMATCH and NEGATE"
-    When using `EXTMATCH` and [`NEGATE`](#fnmatchnegate) together, it is recommended to also use
-    [`MINUSNEGATE`](#fnmatchminusnegate) to avoid conflicts in regards to the `!` meta character.
+
+    When using `EXTMATCH` and [`NEGATE`](#fnmatchnegate) together, if a pattern starts with `!(`, the pattern will not
+    be treated as a [`NEGATE`](#fnmatchnegate) pattern (even if `!(` doesn't yield a valid `EXTMATCH` pattern). To
+    negate a pattern that starts with a literal `(`, you must escape the bracket: `!\(`.
 
 #### `fnmatch.BRACE, fnmatch.B` {: #fnmatchbrace}
 

--- a/docs/src/markdown/glob.md
+++ b/docs/src/markdown/glob.md
@@ -511,10 +511,6 @@ Assuming the [`SPLIT`](#globsplit) flag, this means using it in a pattern such a
 If it is desired, you can force exclusion patterns, when no inclusion pattern is provided, to assume all files match
 unless the file matches the excluded pattern. This is done with the [`NEGATEALL`](#globnegateall) flag.
 
-If used with the extended glob feature, patterns like `!(inverse|pattern)` will be mistakenly parsed as an exclusion
-pattern instead of as an inverse extended glob group.  See [`MINUSNEGATE`](#globminusgate) for an alternative syntax
-that plays nice with extended glob.
-
 !!! warning "Changes 4.0"
     In 4.0, `NEGATE` now requires a non-exclusion pattern to be paired with it or it will match nothing. If you really
     need something similar to the old behavior, that would assume a default inclusion pattern, you can use the
@@ -597,9 +593,11 @@ Alternatively `EXTMATCH` will also be accepted for consistency with the other pr
 the same and are provided as a convenience in case the user finds one more intuitive than the other since `EXTGLOB` is
 often the name used in Bash.
 
-!!! tip "EXTMATCH and NEGATE"
-    When using `EXTMATCH` and [`NEGATE`](#globnegate) together, it is recommended to also use
-    [`MINUSNEGATE`](#globminusnegate) to avoid conflicts in regards to the `!` meta character.
+!!! tip "EXTGLOB and NEGATE"
+
+    When using `EXTGLOB` and [`NEGATE`](#globnegate) together, if a pattern starts with `!(`, the pattern will not
+    be treated as a [`NEGATE`](#globnegate) pattern (even if `!(` doesn't yield a valid `EXTGLOB` pattern). To negate
+    a pattern that starts with a literal `(`, you must escape the bracket: `!\(`.
 
 #### `glob.BRACE, glob.B` {: #globbrace}
 

--- a/docs/src/markdown/pathlib.md
+++ b/docs/src/markdown/pathlib.md
@@ -371,10 +371,6 @@ Assuming the [`SPLIT`](#pathlibsplit) flag, this means using it in a pattern suc
 If it is desired, you can force exclusion patterns, when no inclusion pattern is provided, to assume all files match
 unless the file matches the excluded pattern. This is done with the [`NEGATEALL`](#pathlibnegateall) flag.
 
-If used with the extended glob feature, patterns like `!(inverse|pattern)` will be mistakenly parsed as an exclusion
-pattern instead of as an inverse extended glob group.  See [`MINUSNEGATE`](#pathlibminusnegate) for an alternative
-syntax that plays nice with extended glob.
-
 #### `pathlib.NEGATEALL, pathlib.A` {: #pathlibnegateall}
 
 `NEGATEALL` can force exclusion patterns, when no inclusion pattern is provided, to assume all files match unless the
@@ -439,9 +435,11 @@ Alternatively `EXTMATCH` will also be accepted for consistency with the other pr
 the same and are provided as a convenience in case the user finds one more intuitive than the other since `EXTGLOB` is
 often the name used in Bash.
 
-!!! tip "EXTMATCH and NEGATE"
-    When using `EXTMATCH` and [`NEGATE`](#pathlibnegate) together, it is recommended to also use
-    [`MINUSNEGATE`](#pathlibminusnegate) to avoid conflicts in regards to the `!` meta character.
+!!! tip "EXTGLOB and NEGATE"
+
+    When using `EXTGLOB` and [`NEGATE`](#pathlibnegate) together, if a pattern starts with `!(`, the pattern will not
+    be treated as a [`NEGATE`](#pathlibnegate) pattern (even if `!(` doesn't yield a valid `EXTGLOB` pattern). To negate
+    a pattern that starts with a literal `(`, you must escape the bracket: `!\(`.
 
 #### `pathlib.BRACE, pathlib.B` {: #pathlibbrace}
 

--- a/docs/src/markdown/wcmatch.md
+++ b/docs/src/markdown/wcmatch.md
@@ -340,8 +340,10 @@ handle standard string escapes and Unicode (including `#!py3 r'\N{CHAR NAME}'`).
 etc.
 
 !!! tip "EXTMATCH and NEGATE"
-    When using `EXTMATCH`, it is recommended to also use [`MINUSNEGATE`](#wcmatchminusnegate) to avoid conflicts in
-    regards to the `!` meta character which is used for exclusion patterns..
+
+    When using `EXTMATCH` and [`NEGATE`](#wcmatchnegate) together, if a pattern starts with `!(`, the pattern will not
+    be treated as a [`NEGATE`](#wcmatchnegate) pattern (even if `!(` doesn't yield a valid `EXTMATCH` pattern). To
+    negate a pattern that starts with a literal `(`, you must escape the bracket: `!\(`.
 
 #### `wcmatch.BRACE, wcmatch.B` {: #wcmatchbrace}
 

--- a/tests/test_fnmatch.py
+++ b/tests/test_fnmatch.py
@@ -162,6 +162,16 @@ class TestFnMatch:
         ['[![:alnum:]]bc', '!bc', True, 0],
         ['[^[:alnum:]]bc', '!bc', True, 0],
 
+        # Negation and extended glob together
+        # `!` will be treated as an exclude pattern if it isn't followed by `(`.
+        # `(` must be escaped to exclude a name that starts with `(`.
+        # If `!(` doesn't start a valid extended glob pattern,
+        # it will be treated as a literal, not an exclude pattern.
+        [r'!\(test)', 'test', True, fnmatch.N | fnmatch.E | fnmatch.A],
+        [r'!(test)', 'test', False, fnmatch.N | fnmatch.E | fnmatch.A],
+        [r'!!(test)', 'test', True, fnmatch.N | fnmatch.E | fnmatch.A],
+        [r'!(test', '!(test', True, fnmatch.N | fnmatch.E | fnmatch.A],
+
         # Backwards ranges
         ['[a-z]', 'a', True, 0],
         ['[z-a]', 'a', False, 0],

--- a/tests/test_globmatch.py
+++ b/tests/test_globmatch.py
@@ -392,6 +392,32 @@ class TestGlobFilter:
             ['ac', 'ad', 'cb', 'c,d']
         ],
 
+        # Negation and extended glob together
+        # `!` will be treated as an exclude pattern if it isn't followed by `(`.
+        # `(` must be escaped to exclude a name that starts with `(`.
+        # If `!(` doesn't start a valid extended glob pattern,
+        # it will be treated as a literal, not an exclude pattern.
+        Options(skip_split=True),
+        [
+            r'!\(a|c)',
+            [
+                '(a|b|c)', '(b|c', '*(b|c', 'a', 'ab', 'ac', 'ad', 'b', 'bc', 'bc,d', 'b|c', 'b|cc',
+                'c', 'c,d', 'c,db', 'cb', 'cb|c', 'd', 'd)', 'x(a|b|c)', 'x(a|c)'
+            ],
+            glob.A
+        ],
+        [
+            '!(a|c)',
+            [
+                '(a|b|c)', '(a|c)', '(b|c', '*(b|c', 'ab', 'ac', 'ad', 'b', 'bc', 'bc,d', 'b|c', 'b|cc',
+                'c,d', 'c,db', 'cb', 'cb|c', 'd', 'd)', 'x(a|b|c)', 'x(a|c)'
+            ],
+            glob.A
+        ],
+        ['!!(a|c)', ['a', 'c'], glob.A],
+        ['!(a|c*', [], glob.A],
+        Options(skip_split=False),
+
         # Test `MATCHBASE`.
         [
             'a?b',

--- a/tests/test_wcparse.py
+++ b/tests/test_wcparse.py
@@ -90,3 +90,23 @@ class TestWcparse(unittest.TestCase):
         p1, p2 = _wcparse.translate('{1..11}', _wcparse.BRACE, 0)
         count = len(p1) + len(p2)
         self.assertEqual(count, 11)
+
+    def test_tilde_pos_none(self):
+        """Test that tilde position gives -1 when no tilde found."""
+
+        self.assertEqual(_wcparse.tilde_pos('pattern', _wcparse.GLOBTILDE | _wcparse.REALPATH), -1)
+
+    def test_tilde_pos_normal(self):
+        """Test that tilde position gives 0 when tilde found."""
+
+        self.assertEqual(_wcparse.tilde_pos('~pattern', _wcparse.GLOBTILDE | _wcparse.REALPATH), 0)
+
+    def test_tilde_pos_negative_normal(self):
+        """Test that tilde position gives 0 when tilde is found and `NEGATE` is enabled."""
+
+        self.assertEqual(_wcparse.tilde_pos('~pattern', _wcparse.GLOBTILDE | _wcparse.REALPATH | _wcparse.NEGATE), 0)
+
+    def test_tilde_pos_negative_negate(self):
+        """Test that tilde position gives 1 when tilde is found and `NEGATE` is enabled."""
+
+        self.assertEqual(_wcparse.tilde_pos('!~pattern', _wcparse.GLOBTILDE | _wcparse.REALPATH | _wcparse.NEGATE), 1)

--- a/wcmatch/__meta__.py
+++ b/wcmatch/__meta__.py
@@ -186,5 +186,5 @@ def parse_version(ver, pre=False):
     return Version(major, minor, micro, release, pre, post, dev)
 
 
-__version_info__ = Version(6, 0, 3, "final")
+__version_info__ = Version(6, 1, 0, ".dev")
 __version__ = __version_info__._get_canonical()

--- a/wcmatch/glob.py
+++ b/wcmatch/glob.py
@@ -185,13 +185,12 @@ class Glob(object):
 
         self.pattern = []
         self.npatterns = []
-        nflags = self.flags | REALPATH
         for is_neg, p in self._iter_patterns(patterns):
             if is_neg:
                 # Treat the inverse pattern as a normal pattern if it matches, we will exclude.
                 # This is faster as compiled patterns usually compare the include patterns first,
                 # and then the exclude, but glob will already know it wants to include the file.
-                self.npatterns.append(_wcparse._compile(p, nflags))
+                self.npatterns.append(_wcparse._compile(p, self.flags))
             else:
                 self.pattern.append(_wcparse.WcPathSplit(p, self.flags).split())
 


### PR DESCRIPTION
If at anytime, !( is found at the start of a path, and NEGATE and
EXTGLOB are enabled at the same time, the pattern will be parsed as
EXTGLOB. If the parse fails to find a valid EXTGLOB pattern, !( will
be treated as a literal !( and not as a NEGATE pattern.