### PR TITLE
Allow identifying a NEGATE pattern when a EXTGLOB !( pattern fails

### DIFF
--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -2,9 +2,8 @@
 
 ## 6.1.0
 
-- **NEW**: `EXTMATCH`/`EXTGLOB` can now be used with `NEGATE` without needing `MINUSNEGATE`. If a pattern starts with
-  `!(`, the pattern will not be treated as a `NEGATE` pattern (even if `!(` doesn't yield a valid `EXTGLOB` pattern).
-  To negate a pattern that starts with a literal `(`, you must escape the bracket: `!\(`.
+- **NEW**: `EXTMATCH`/`EXTGLOB` can now be used with `NEGATE` without needing `MINUSNEGATE`. Logic is now present to
+  distinguish between `!` and a valid `!(...)`.
 
 ## 6.0.3
 

--- a/docs/src/markdown/fnmatch.md
+++ b/docs/src/markdown/fnmatch.md
@@ -211,9 +211,8 @@ etc. See the [syntax overview](#syntax) for more information.
 
 !!! tip "EXTMATCH and NEGATE"
 
-    When using `EXTMATCH` and [`NEGATE`](#fnmatchnegate) together, if a pattern starts with `!(`, the pattern will not
-    be treated as a [`NEGATE`](#fnmatchnegate) pattern (even if `!(` doesn't yield a valid `EXTMATCH` pattern). To
-    negate a pattern that starts with a literal `(`, you must escape the bracket: `!\(`.
+    When using `EXTMATCH` and [`NEGATE`](#fnmatchnegate) together, remember to escape `\(` to help distinguish between.
+    `!` and `!(...)`.
 
 #### `fnmatch.BRACE, fnmatch.B` {: #fnmatchbrace}
 

--- a/docs/src/markdown/glob.md
+++ b/docs/src/markdown/glob.md
@@ -595,9 +595,8 @@ often the name used in Bash.
 
 !!! tip "EXTGLOB and NEGATE"
 
-    When using `EXTGLOB` and [`NEGATE`](#globnegate) together, if a pattern starts with `!(`, the pattern will not
-    be treated as a [`NEGATE`](#globnegate) pattern (even if `!(` doesn't yield a valid `EXTGLOB` pattern). To negate
-    a pattern that starts with a literal `(`, you must escape the bracket: `!\(`.
+    When using `EXTGLOB` and [`NEGATE`](#globnegate) together, remember to escape `\(` to help distinguish between.
+    `!` and `!(...)`.
 
 #### `glob.BRACE, glob.B` {: #globbrace}
 

--- a/docs/src/markdown/pathlib.md
+++ b/docs/src/markdown/pathlib.md
@@ -437,9 +437,8 @@ often the name used in Bash.
 
 !!! tip "EXTGLOB and NEGATE"
 
-    When using `EXTGLOB` and [`NEGATE`](#pathlibnegate) together, if a pattern starts with `!(`, the pattern will not
-    be treated as a [`NEGATE`](#pathlibnegate) pattern (even if `!(` doesn't yield a valid `EXTGLOB` pattern). To negate
-    a pattern that starts with a literal `(`, you must escape the bracket: `!\(`.
+    When using `EXTGLOB` and [`NEGATE`](#pathlibnegate) together, remember to escape `\(` to help distinguish between.
+    `!` and `!(...)`.
 
 #### `pathlib.BRACE, pathlib.B` {: #pathlibbrace}
 

--- a/docs/src/markdown/wcmatch.md
+++ b/docs/src/markdown/wcmatch.md
@@ -341,9 +341,8 @@ etc.
 
 !!! tip "EXTMATCH and NEGATE"
 
-    When using `EXTMATCH` and [`NEGATE`](#wcmatchnegate) together, if a pattern starts with `!(`, the pattern will not
-    be treated as a [`NEGATE`](#wcmatchnegate) pattern (even if `!(` doesn't yield a valid `EXTMATCH` pattern). To
-    negate a pattern that starts with a literal `(`, you must escape the bracket: `!\(`.
+    When using `EXTMATCH` and [`NEGATE`](#wcmatchnegate) together, remember to escape `\(` to help distinguish between.
+    `!` and `!(...)`.
 
 #### `wcmatch.BRACE, wcmatch.B` {: #wcmatchbrace}
 

--- a/tests/test_fnmatch.py
+++ b/tests/test_fnmatch.py
@@ -170,6 +170,7 @@ class TestFnMatch:
         [r'!\(test)', 'test', True, fnmatch.N | fnmatch.E | fnmatch.A],
         [r'!(test)', 'test', False, fnmatch.N | fnmatch.E | fnmatch.A],
         [r'!!(test)', 'test', True, fnmatch.N | fnmatch.E | fnmatch.A],
+        [r'!(test', '(test', False, fnmatch.N | fnmatch.E | fnmatch.A],
         [r'!(test', '!(test', True, fnmatch.N | fnmatch.E | fnmatch.A],
 
         # Backwards ranges

--- a/tests/test_globmatch.py
+++ b/tests/test_globmatch.py
@@ -415,7 +415,14 @@ class TestGlobFilter:
             glob.A
         ],
         ['!!(a|c)', ['a', 'c'], glob.A],
-        ['!(a|c*', [], glob.A],
+        [
+            '!(a|c*',
+            [
+                '(a|b|c)', '(b|c', '*(b|c', 'a', 'ab', 'ac', 'ad', 'b', 'bc', 'bc,d', 'b|c', 'b|cc',
+                'c', 'c,d', 'c,db', 'cb', 'cb|c', 'd', 'd)', 'x(a|b|c)', 'x(a|c)'
+            ],
+            glob.A
+        ],
         Options(skip_split=False),
 
         # Test `MATCHBASE`.


### PR DESCRIPTION
When NEGATE and EXTGLOB/EXTMATCH are enabled at the same time, and a
pattern that starts with !( is tested for !(...) and fails to evaluate,
fallback to treating the path as a NEGATE pattern.