### PR TITLE
Refactor escape logic for Windows drives

### DIFF
--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -3,7 +3,8 @@
 ## 6.1
 
 - **NEW**: Recognize extended UNC, such as: `//?/UNC/server/mount`, `//?/UNC/c:`, etc.
-- **NEW**: Allow escaping `{`, `}` and `|` in Windows drives for better compatibility with `SPLIT` and `BRACE`.
+- **NEW**: Allow escaping any character in Windows drives for better compatibility with `SPLIT` and `BRACE` which
+  requires a user to eascape `{`, `}` and `|` to avoid expanding a pattern.
 - **NEW**: `raw_escape` now accepts the `raw_chars` parameter so that translation of Python raw escapes can be disabled.
 - **NEW**: `EXTMATCH`/`EXTGLOB` can now be used with `NEGATE` without needing `MINUSNEGATE`. If a pattern starts with
   `!(`, and `NEGATE` and `EXTMATCH`/`EXTGLOB` are both enabled, the pattern will not be treated as a `NEGATE` pattern

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -4,7 +4,7 @@
 
 - **NEW**: Recognize extended UNC, such as: `//?/UNC/server/mount`, `//?/UNC/c:`, etc.
 - **NEW**: Allow escaping any character in Windows drives for better compatibility with `SPLIT` and `BRACE` which
-  requires a user to eascape `{`, `}` and `|` to avoid expanding a pattern.
+  requires a user to escape `{`, `}` and `|` to avoid expanding a pattern.
 - **NEW**: `raw_escape` now accepts the `raw_chars` parameter so that translation of Python raw escapes can be disabled.
 - **NEW**: `EXTMATCH`/`EXTGLOB` can now be used with `NEGATE` without needing `MINUSNEGATE`. If a pattern starts with
   `!(`, and `NEGATE` and `EXTMATCH`/`EXTGLOB` are both enabled, the pattern will not be treated as a `NEGATE` pattern
@@ -13,6 +13,7 @@
 - **FIX**: Support Python 3.9.
 - **FIX**: Adjust pattern limit logic of `glob` to be consistent with other functions.
 - **BUG**: Fix corner cases with `escape` and `raw_escape` with back slashes.
+- **BUG**: Ensure that `globmatch` does not match `test//` with pattern `test/*`.
 
 ## 6.0.3
 

--- a/tests/test_globmatch.py
+++ b/tests/test_globmatch.py
@@ -2,6 +2,7 @@
 """Tests for `globmatch`."""
 import unittest
 import pytest
+import re
 import os
 import sys
 import wcmatch.glob as glob
@@ -612,6 +613,16 @@ class TestGlobFilter:
         ['TEST/test', [], glob.U],
         ['test\\/TEST', [], glob.U],
 
+        # Ensure we don't count slashes with `*`.
+        GlobFiles(['test/test', 'test//']),
+
+        ['test/*', ['test/test']],
+        ['test/*', ['test/test'], glob.W],
+
+        GlobFiles(['test\\test', 'test\\\\']),
+
+        ['test/*', ['test\\test'], glob.W],
+
         GlobFiles(['c:/some/path', '//host/share/some/path']),
 
         # Test Windows drive and UNC host/share case sensitivity
@@ -986,8 +997,8 @@ class TestGlobMatchSpecial(unittest.TestCase):
         if util.PY37:
             value = (
                 [
-                    '^(?s:(?:(?!(?:/|^)\\.).)*?(?:^|$|/)+'
-                    '(?!(?:\\.{1,2})(?:$|/))(?![/.])[\x00-\x7f]/+stuff/+(?=.)'
+                    '^(?s:(?:(?!(?:/|^)\\.).)*?(?:^|$|/)+' +
+                    ('(?!(?:\\.{1,2})(?:$|/))(?![/.])[\x00-\x7f]/+stuff/+(?=[^%s])' % re.escape('/')) +
                     '(?!(?:\\.{1,2})(?:$|/))(?:(?!\\.)[^/]*?)?[/]*?)$'
                 ],
                 []
@@ -995,8 +1006,8 @@ class TestGlobMatchSpecial(unittest.TestCase):
         elif util.PY36:
             value = (
                 [
-                    '^(?s:(?:(?!(?:\\/|^)\\.).)*?(?:^|$|\\/)+'
-                    '(?!(?:\\.{1,2})(?:$|\\/))(?![\\/.])[\x00-\x7f]\\/+stuff\\/+(?=.)'
+                    '^(?s:(?:(?!(?:\\/|^)\\.).)*?(?:^|$|\\/)+' +
+                    ('(?!(?:\\.{1,2})(?:$|\\/))(?![\\/.])[\x00-\x7f]\\/+stuff\\/+(?=[^%s])' % re.escape('/')) +
                     '(?!(?:\\.{1,2})(?:$|\\/))(?:(?!\\.)[^\\/]*?)?[\\/]*?)$'
                 ],
                 []
@@ -1004,8 +1015,8 @@ class TestGlobMatchSpecial(unittest.TestCase):
         else:
             value = (
                 [
-                    '(?s)^(?:(?:(?!(?:\\/|^)\\.).)*?(?:^|$|\\/)+'
-                    '(?!(?:\\.{1,2})(?:$|\\/))(?![\\/.])[\x00-\x7f]\\/+stuff\\/+(?=.)'
+                    '(?s)^(?:(?:(?!(?:\\/|^)\\.).)*?(?:^|$|\\/)+' +
+                    ('(?!(?:\\.{1,2})(?:$|\\/))(?![\\/.])[\x00-\x7f]\\/+stuff\\/+(?=[^%s])' % re.escape('/')) +
                     '(?!(?:\\.{1,2})(?:$|\\/))(?:(?!\\.)[^\\/]*?)?[\\/]*?)$'
                 ],
                 []

--- a/tests/test_globmatch.py
+++ b/tests/test_globmatch.py
@@ -659,7 +659,33 @@ class TestGlobFilter:
                 b".", b"..", b"...", b'.../', b"test/", b"file", b"/file"
             ]
         ),
-        [b'**/*', [b'...', b'file', b'test/...', b'test/.file', b"/file"], glob.O | glob.D]
+        [b'**/*', [b'...', b'file', b'test/...', b'test/.file', b"/file"], glob.O | glob.D],
+
+        # Test Windows drives
+        GlobFiles(
+            [
+                '//?/UNC/LOCALHOST/c$/temp', '//./UNC/LOCALHOST/c$/temp', '//?/GLOBAL/UNC/LOCALHOST/c$/temp',
+                '//?/GLOBAL/global/UNC/LOCALHOST/c$/temp', '//?/C:/temp'
+            ]
+        ),
+
+        ['//?/unc/localhost/c$/*', ['//?/UNC/LOCALHOST/c$/temp'], glob.W],
+        ['//./unc/localhost/c$/*', ['//./UNC/LOCALHOST/c$/temp'], glob.W],
+        ['//?/global/unc/localhost/c$/*', ['//?/GLOBAL/UNC/LOCALHOST/c$/temp'], glob.W],
+        ['//?/global/global/unc/localhost/c$/*', ['//?/GLOBAL/global/UNC/LOCALHOST/c$/temp'], glob.W],
+        ['//?/c:/*', ['//?/C:/temp'], glob.W],
+
+        GlobFiles(
+            [
+                b'//?/UNC/LOCALHOST/c$/temp', b'//./UNC/LOCALHOST/c$/temp', b'//?/GLOBAL/UNC/LOCALHOST/c$/temp',
+                b'//?/GLOBAL/global/UNC/LOCALHOST/c$/temp', b'//?/C:/temp'
+            ]
+        ),
+        [b'//?/unc/localhost/c$/*', [b'//?/UNC/LOCALHOST/c$/temp'], glob.W],
+        [b'//./unc/localhost/c$/*', [b'//./UNC/LOCALHOST/c$/temp'], glob.W],
+        [b'//?/global/unc/localhost/c$/*', [b'//?/GLOBAL/UNC/LOCALHOST/c$/temp'], glob.W],
+        [b'//?/global/global/unc/localhost/c$/*', [b'//?/GLOBAL/global/UNC/LOCALHOST/c$/temp'], glob.W],
+        [b'//?/c:/*', [b'//?/C:/temp'], glob.W]
     ]
 
     @classmethod

--- a/tests/test_pathlib.py
+++ b/tests/test_pathlib.py
@@ -178,6 +178,7 @@ class TestPathlibGlobmatch:
         if path is None:
             path = pathlib.Path(name)
 
+        print('PATH: ', str(path))
         print("PATTERN: ", pattern)
         print("FILE: ", name)
         print("GOAL: ", goal)

--- a/wcmatch/_wcparse.py
+++ b/wcmatch/_wcparse.py
@@ -332,9 +332,10 @@ def _get_win_drive(pattern, regex=False, case_sensitive=False):
     if m:
         end = m.end(0)
         if m.group(3) and RE_WIN_DRIVE_LETTER.match(m.group(0)):
-            drive = RE_WIN_DRIVE_UNESCAPE.sub(r'\1', m.group(3))
             if regex:
-                drive = escape_drive(drive, case_sensitive)
+                drive = escape_drive(RE_WIN_DRIVE_UNESCAPE.sub(r'\1', m.group(0)), case_sensitive)
+            else:
+                drive = m.group(0)
             slash = bool(m.group(4))
             root_specified = True
         elif m.group(2):
@@ -358,7 +359,7 @@ def _get_win_drive(pattern, regex=False, case_sensitive=False):
                     break
             if count == complete:
                 if not regex:
-                    drive = '\\\\' + '\\'.join(part)
+                    drive = '\\\\{}\\'.format('\\'.join(part))
                 else:
                     drive = r'[\\/]{2}' + r'[\\/]'.join([escape_drive(p, case_sensitive) for p in part])
     elif pattern.startswith('\\\\'):
@@ -764,8 +765,8 @@ class WcPathSplit(object):
                 if self.is_bytes:
                     drive = drive.encode('latin-1')
                 parts.append(WcGlob(drive, False, False, True, True))
-                i.advance(end)
-                start = end
+                start = end - 1
+                i.advance(start)
             elif drive is None and root_specified:
                 parts.append(WcGlob(b'\\' if self.is_bytes else '\\', False, False, True, True))
                 start = 1


### PR DESCRIPTION
Users can now escape any characters in Windows drives. This is done
so:

1. users can properly escape `{}|` characters in Windows drives.
2. also to be forgiving if a user gets confused and thinks they should
escape special chars in Windows drives.

Any escapes will be treated simply as the character itself.