### PR TITLE
"scandir" and symlink following fix

### DIFF
--- a/docs/src/dictionary/en-custom.txt
+++ b/docs/src/dictionary/en-custom.txt
@@ -20,6 +20,7 @@ Pathlib
 Preprocess
 PyPI
 Symlink
+TODO
 Twemoji
 UNC
 Wcmatch

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -25,8 +25,7 @@ Check out [Release Notes](./release.md#upgrade-to-70) to learn more about upgrad
   are only returned when `NOUNIQUE` is not enabled.
 - **FIX**: Fix corner cases with `escape` and `raw_escape` with back slashes.
 - **FIX**: Ensure that `globmatch` does not match `test//` with pattern `test/*`.
-- **FIX**: `pathlib.match` should not evaluate symlinks (when using `REALPATH`) that are on the left hand side of what
-  was matched.
+- **FIX**: `pathlib.match` should not evaluate symlinks that are on the left hand side of what was matched.
 
 ## 6.1
 

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -9,21 +9,24 @@ Check out [Release Notes](./release.md#upgrade-to-70) to learn more about upgrad
   requires a user to escape `{`, `}` and `|` to avoid expanding a pattern.
 - **NEW**: `raw_escape` now accepts the `raw_chars` parameter so that translation of Python character back references
   can be disabled.
-- **NEW**: Search functions that crawl the filesystem, such as `glob.glob`, `glob.iglob`, `pathlib.Path.glob`, and
-  `pathlib.Path.rglob`, will no longer return `.` and `..` with magic patterns such as `.*`. A literal pattern of `.`
-  and `..` is required to match the special directories `.` and `..`.
-- **NEW**: Add `SCANDOTDIR` flag to enable previous behavior in search functions that caused pattern like `.*` to match
-  `.` and `..`.
+- **NEW**: Search functions that use `scandir` will not return `.` and `..` for wildcard patterns that require iterating
+  over a directory to match the files against a pattern. This matches Python's glob and is most likely what most users
+  expect. Using a literal `.` or `..` in a pattern will still cause `.` and `..` to be matched.
+- **NEW**: Add `SCANDOTDIR` flag to enable previous behavior of injecting `.` and `..` in `scandir` results.
+  This means that wildcard patterns (such as `.*`) will cause `glob` to return `.` and `..`, which matches Bash's
+  behavior. This only controls `scandir` behavior and will not affect match patterns in things like `globmatch`.
 - **NEW**: Flag `NODOTDIR` has been added to disable patterns such as `.*` from matching `.` and `..` in matching
   functions (that don't crawl the filesystem) such as `globmatch`, `pathlib.PurePath.match`, etc. When enabled, matching
   functions will require a literal pattern of `.` and `..` to match the special directories `.` and `..`.
-- **FIX**: Negative extended glob patterns (`!(...)`) incorrectly allowed for hidden files to be returned when one of the
-  subpatterns started with `.`, even when `DOTMATCH`/`DOTGLOB` was not enabled.
+- **FIX**: Negative extended glob patterns (`!(...)`) incorrectly allowed for hidden files to be returned when one of
+  the subpatterns started with `.`, even when `DOTMATCH`/`DOTGLOB` was not enabled.
 - **FIX**: When `NOUNIQUE` is enabled and `pathlib` is being used, you could still get non-unique results across
   patterns expanded with `BRACE` or `SPLIT` (or even by simply providing a list of patterns). Ensure that unique results
   are only returned when `NOUNIQUE` is not enabled.
 - **FIX**: Fix corner cases with `escape` and `raw_escape` with back slashes.
 - **FIX**: Ensure that `globmatch` does not match `test//` with pattern `test/*`.
+- **FIX**: `pathlib.match` should not evaluate symlinks (when using `REALPATH`) that are on the left hand side of what
+  was matched.
 
 ## 6.1
 

--- a/docs/src/markdown/fnmatch.md
+++ b/docs/src/markdown/fnmatch.md
@@ -145,7 +145,7 @@ matched if it matches at least one inclusion pattern and matches **none** of the
 (['^(?s:(?=.)(?![.]).*?)$'], ['^(?s:(?=.).*?\\.a)$', '^(?s:(?=.).*?\\.b)$', '^(?s:(?=.).*?\\.c)$'])
 ```
 
-!!! warning "Changed 4.0"
+!!! new "Changes 4.0"
     Translate now outputs exclusion patterns so that if they match, the file is excluded. This is opposite logic to how
     it used to be, but is more efficient.
 

--- a/docs/theme/main.html
+++ b/docs/theme/main.html
@@ -1,0 +1,6 @@
+{% extends "base.html" %}
+
+{% block announce %}
+<span class="twemoji"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M23 12l-2.44-2.78.34-3.68-3.61-.82-1.89-3.18L12 3 8.6 1.54 6.71 4.72l-3.61.81.34 3.68L1 12l2.44 2.78-.34 3.69 3.61.82 1.89 3.18L12 21l3.4 1.46 1.89-3.18 3.61-.82-.34-3.68L23 12m-10 5h-2v-2h2v2m0-4h-2V7h2v6z"></path></svg></span>
+7.0 has been released! Check out the <a href="about/release/#upgrade-to-70">Release Notes</a> for more information and migration tips.
+{% endblock %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,6 +8,7 @@ copyright: |
 
 docs_dir: docs/src/markdown
 theme:
+  custom_dir: docs/theme
   name: material
   icon:
     logo: material/book-open-page-variant
@@ -68,8 +69,8 @@ markdown_extensions:
   - pymdownx.caret:
   - pymdownx.smartsymbols:
   - pymdownx.emoji:
-      emoji_index: !!python/name:pymdownx.emoji.twemoji
-      emoji_generator: !!python/name:pymdownx.emoji.to_svg
+      emoji_index: !!python/name:materialx.emoji.twemoji
+      emoji_generator: !!python/name:materialx.emoji.to_svg
   - pymdownx.escapeall:
       hardbreak: True
       nbsp: True

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,4 +1,4 @@
-mkdocs_pymdownx_material_extras==1.0.3
+mkdocs_pymdownx_material_extras==1.0.4
 mkdocs-git-revision-date-localized-plugin
 mkdocs-minify-plugin
 pyspelling

--- a/tests/test_glob.py
+++ b/tests/test_glob.py
@@ -1041,7 +1041,30 @@ class TestHidden(_TestGlob):
                 ('a', '.'), ('a', '..'), ('.aa', '..')
             ],
             glob.D | glob.S | glob.SCANDOTDIR | glob._PATHLIB
-        ]
+        ],
+
+        Options(default_negate='**/./.*/*'),
+
+        # `SCANDOTDIR` does not change our patterns (the negate pattern for instance),
+        # just what is returned when scanning a folder with a wildcard.
+        [
+            ('**', '.*', '.aa', '*'),
+            [
+                ('.', '.bb', 'H')
+            ],
+            glob.D | glob.S | glob.N
+        ],
+
+        # Should we allow this? Or should `NODOTDIR` not apply to `NEGATE` patterns.
+        [
+            ('**', '.*', '.aa', '*'),
+            [
+                ('.', '.bb', 'H'), ('.', '.aa', 'G')
+            ],
+            glob.D | glob.S | glob.N | glob.Z
+        ],
+
+        Options(default_negate='**')
     ]
 
     @classmethod

--- a/wcmatch/_wcparse.py
+++ b/wcmatch/_wcparse.py
@@ -1677,6 +1677,7 @@ class WcParse(object):
         p = p.decode('latin-1') if self.is_bytes else p
 
         if self.negative:
+            # TODO: Do we prevent `NODOTDIR` for negative patterns?
             self.globstar_capture = False
             self.dot = True
 
@@ -1694,16 +1695,22 @@ class WcParse(object):
             self.globstar = globstar
 
         elif self.rtl:
+            # Add a `**` that can capture anything: dots, special directories, symlinks, etc.
+            # We are simulating right to left, so everything on the left should be accepted without
+            # question.
             globstar = self.globstar
             dot = self.dot
             gstar = self.path_gstar_dot1
+            globstar_capture = self.globstar_capture
             self.path_gstar_dot1 = _PATH_GSTAR_RTL_MATCH
             self.dot = True
             self.globstar = True
+            self.globstar_capture = False
             self.root('**', prepend)
             self.globstar = globstar
             self.dot = dot
             self.path_gstar_dot1 = gstar
+            self.globstar_capture = globstar_capture
 
         if p:
             self.root(p, result)

--- a/wcmatch/glob.py
+++ b/wcmatch/glob.py
@@ -161,6 +161,7 @@ class Glob(object):
         if flags & _RTL:  # pragma: no cover
             flags ^= _RTL
         self.flags = _flag_transform(flags | REALPATH)
+        self.negate_flags = self.flags
         if not self.scandotdir and not self.flags & NODOTDIR:
             self.flags |= NODOTDIR
         self.raw_chars = bool(self.flags & RAWCHARS)
@@ -217,7 +218,7 @@ class Glob(object):
                 # Treat the inverse pattern as a normal pattern if it matches, we will exclude.
                 # This is faster as compiled patterns usually compare the include patterns first,
                 # and then the exclude, but glob will already know it wants to include the file.
-                self.npatterns.append(_wcparse._compile(p, self.flags))
+                self.npatterns.append(_wcparse._compile(p, self.negate_flags))
             else:
                 self.pattern.append(_wcparse.WcPathSplit(p, self.flags).split())
 


### PR DESCRIPTION
- New "scandir" logic should not affect pattern handling
- pathlib.match should not following symlinks of the leftmost portion
  of what was matched.