### PR TITLE
Better checking and failure of mismatched str and byte types in glob

### DIFF
--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 8.0.2
+
+- **FIX**: Use `os.fspath` to convert path-like objects to string, whatever the preferred return for `os.path` is what
+  Wildcard Match will accept. Don't try to convert paths via `__str__` or `__bytes__`.
+- **FIX**: Better checking of types to ensure consistent failure if the path, pattern, or root directory of are not all
+  of type `str` or `bytes`.
+
 ## 8.0.1
 
 - **FIX**: Small bug in `[:alpha:]` range.

--- a/tests/test_glob.py
+++ b/tests/test_glob.py
@@ -1127,11 +1127,6 @@ class TestCWD(_TestGlob):
 
         self.assert_equal(glob.glob('EF', root_dir=pathlib.Path(self.tempdir)), ['EF'])
 
-    def test_cwd_root_dir_pathlike_bytes(self):
-        """Test root level glob when we switch directory via `root_dir` with a path-like object."""
-
-        self.assert_equal(glob.glob(b'EF', root_dir=pathlib.Path(self.tempdir)), [b'EF'])
-
 
 class TestGlobCornerCase(_TestGlob):
     """
@@ -1463,3 +1458,25 @@ class TestExpansionLimit(unittest.TestCase):
 
         with self.assertRaises(_wcparse.PatternLimitException):
             list(glob.iglob('{1..11}', flags=glob.BRACE, limit=10))
+
+
+class TestInputTypes(unittest.TestCase):
+    """Test input types."""
+
+    def test_cwd_root_dir_pathlike_bytes_str(self):
+        """Test root level glob when we switch directory via `root_dir` with a path-like object."""
+
+        with self.assertRaises(TypeError):
+            glob.glob(b'docs/*', root_dir=pathlib.Path('.'))
+
+    def test_cwd_root_dir_bytes_str(self):
+        """Test root level glob when we switch directory via `root_dir` with a path-like object."""
+
+        with self.assertRaises(TypeError):
+            glob.glob(b'docs/*', root_dir='.')
+
+    def test_cwd_root_dir_str_bytes(self):
+        """Test root level glob when we switch directory via `root_dir` with a path-like object."""
+
+        with self.assertRaises(TypeError):
+            glob.glob('docs/*', root_dir=b'.')

--- a/tests/test_globmatch.py
+++ b/tests/test_globmatch.py
@@ -1526,19 +1526,65 @@ class TestGlobMatchSpecial(unittest.TestCase):
             glob.globmatch(pathlib.Path('markdown'), 'markdown', flags=glob.REALPATH, root_dir=pathlib.Path('docs/src'))
         )
 
-    def test_match_root_dir_pathlib_bytes(self):
-        """Test root directory with `globmatch` using `pathlib`."""
+    def test_match_pathlib_str_bytes(self):
+        """Test that mismatch type of `pathlib` and `bytes` asserts."""
 
         from wcmatch import pathlib
 
-        self.assertFalse(glob.globmatch(pathlib.Path('markdown'), b'markdown', flags=glob.REALPATH))
-        self.assertTrue(
+        with self.assertRaises(TypeError):
+            glob.globmatch(pathlib.Path('markdown'), b'markdown')
+
+    def test_match_str_bytes(self):
+        """Test that mismatch type of `str` and `bytes` asserts."""
+
+        with self.assertRaises(TypeError):
+            glob.globmatch('markdown', b'markdown')
+
+    def test_match_bytes_pathlib_str_realpath(self):
+        """Test that mismatch type of `pathlib` and bytes asserts."""
+
+        from wcmatch import pathlib
+
+        with self.assertRaises(TypeError):
             glob.globmatch(
                 pathlib.Path('markdown'),
-                b'markdown', flags=glob.REALPATH,
-                root_dir=pathlib.Path('docs/src')
+                b'markdown', flags=glob.REALPATH
             )
-        )
+
+    def test_match_bytes_root_dir_pathlib_realpath(self):
+        """Test that mismatch type of root directory `pathlib` and `bytes` asserts."""
+
+        from wcmatch import pathlib
+
+        with self.assertRaises(TypeError):
+            glob.globmatch(
+                b'markdown',
+                b'markdown',
+                flags=glob.REALPATH,
+                root_dir=pathlib.Path('.')
+            )
+
+    def test_match_bytes_root_dir_str_realpath(self):
+        """Test that mismatch type of root directory `pathlib` and `bytes` asserts."""
+
+        with self.assertRaises(TypeError):
+            glob.globmatch(
+                b'markdown',
+                b'markdown',
+                flags=glob.REALPATH,
+                root_dir='.'
+            )
+
+    def test_match_str_root_dir_bytes_realpath(self):
+        """Test that mismatch type of root directory of `bytes` and `str` asserts."""
+
+        with self.assertRaises(TypeError):
+            glob.globmatch(
+                'markdown',
+                'markdown',
+                flags=glob.REALPATH,
+                root_dir=b'.'
+            )
 
     def test_filter_root_dir_pathlib(self):
         """Test root directory with `globfilter`."""
@@ -1559,14 +1605,13 @@ class TestGlobMatchSpecial(unittest.TestCase):
 
         from wcmatch import pathlib
 
-        results = glob.globfilter(
-            [pathlib.Path('markdown')],
-            b'markdown',
-            flags=glob.REALPATH,
-            root_dir=pathlib.Path('docs/src')
-        )
-
-        self.assertTrue(all([isinstance(result, pathlib.Path) for result in results]))
+        with self.assertRaises(TypeError):
+            glob.globfilter(
+                [pathlib.Path('markdown')],
+                b'markdown',
+                flags=glob.REALPATH,
+                root_dir=pathlib.Path('docs/src')
+            )
 
 
 @skip_unless_symlink

--- a/wcmatch/__meta__.py
+++ b/wcmatch/__meta__.py
@@ -186,5 +186,5 @@ def parse_version(ver, pre=False):
     return Version(major, minor, micro, release, pre, post, dev)
 
 
-__version_info__ = Version(8, 0, 1, "final")
+__version_info__ = Version(8, 0, 2, ".dev")
 __version__ = __version_info__._get_canonical()

--- a/wcmatch/_wcparse.py
+++ b/wcmatch/_wcparse.py
@@ -1837,6 +1837,20 @@ def _match_pattern(filename, include, exclude, real, path, follow, root_dir=None
             root = root_dir if root_dir else '.'
             ptype = UNICODE
 
+        if type(filename) != type(root):
+            raise TypeError(
+                "The filename and root directory should be of the same type, not {} and {}".format(
+                    type(filename), type(root_dir)
+                )
+            )
+
+        if include and type(include[0].pattern) != type(filename):
+            raise TypeError(
+                "The filename and pattern should be of the same type, not {} and {}".format(
+                    type(filename), type(include[0].pattern)
+                )
+            )
+
         mount = RE_WIN_MOUNT[ptype] if util.platform() == "windows" else RE_MOUNT[ptype]
 
         if not mount.match(filename):

--- a/wcmatch/util.py
+++ b/wcmatch/util.py
@@ -256,15 +256,3 @@ def warn_deprecated(message, stacklevel=2):  # pragma: no cover
         category=DeprecationWarning,
         stacklevel=stacklevel
     )
-
-
-def fscodec(path, encode=False):
-    """
-    Provide common interface when using to translate path-like files.
-
-    Python 3.5 does not support `os.PathLike` interfaces, so we only return strings and bytes.
-    """
-
-    if not isinstance(path, (str, bytes)):
-        path = os.fsencode(path) if encode else os.fsdecode(path)
-    return path


### PR DESCRIPTION
- Use `os.fspath` to convert path-like objects to string, whatever the
  preferred return for `os.path` is what Wildcard Match will accept.
  Don't try to convert paths via `__str__` or `__bytes__`.
- Better checking of types to ensure consistent failure if the path,
  pattern, or root directory of are not all of type `str` or `bytes`.