### PR TITLE
Deprecate raw_escape

### DIFF
--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -3,8 +3,10 @@
 ## 8.1.dev
 
 - **NEW**: Add `is_magic` function to the `glob` and `fnamtch` library.
-- **NEW**: `fnmatch` now has `escape` and `raw_escape` available via its API. `fnmatch` variants use filename logic
-  instead of path logic.
+- **NEW**: `fnmatch` now has `escape` available via its API. The `fnmatch` variant uses filename logic instead of path
+  logic.
+- **NEW**: Deprecate `raw_escape` in `glob` as it is very niche and the same can be accomplished simply by using
+  `#!py3 codecs.decode(string, 'unicode_escape')` and then using `escape`.
 - **FIX**: Use `os.fspath` to convert path-like objects to string, whatever the preferred return for `os.path` is what
   Wildcard Match will accept. Don't try to convert paths via `__str__` or `__bytes__`.
 - **FIX**: Better checking of types to ensure consistent failure if the path, pattern, or root directory of are not all

--- a/docs/src/markdown/fnmatch.md
+++ b/docs/src/markdown/fnmatch.md
@@ -186,58 +186,6 @@ True
 !!! new "New 8.1"
     An `escape` variant for `fnmatch` was made available in 8.1.
 
-#### `glob.raw_escape` {: #raw_escape}
-
-```py3
-def raw_escape(pattern, raw_chars=True):
-```
-
-`raw_escape` is kind of a niche function and 99% of the time, it is recommended to use [`escape`](#escape).
-
-The big difference between `raw_escape` and [`escape`](#escape) is how `\` are handled. `raw_escape` is mainly for
-filenames provided to Python via an interface that doesn't process Python strings like they normally are, for instance
-an input in a GUI.
-
-To illustrate, you may have an interface to input path names, but may want to take advantage of Python Unicode
-references. Normally, on a python command line, you can do this:
-
-```pycon3
->>> 'El Ni\u00f1o'
-'El Niño'
-```
-
-But when in a GUI interface, if a user inputs the same, it's like getting a raw string.
-
-```pycon3
->>> r'El Ni\u00f1o'
-'El Ni\\u00f1o'
-```
-
-`raw_escape` will take a raw string in the above format and resolve character escapes and escape the filename as if it
-was a normal string. Backslashes aren't normally used in filenames, but if we wanted to use them, we must treat literal
-backslashes as an escaped backslash.
-
-```pycon3
->>> fnmatch.escape('folder\\El Ni\u00f1o', unix=False)
-'folder\\\\El Niño'
->>> fnmatch.raw_escape(r'folder\\El Ni\u00f1o')
-'folder\\\\El Niño'
-```
-
-Handling of raw character references can be turned off if desired:
-
-```pycon3
->>> glob.raw_escape(r'my\\file-\x31.txt', unix=False)
-'my\\\\file\\-1.txt'
->>> glob.raw_escape(r'my\\file-\x31.txt', unix=False, raw_chars=False)
-'my\\\\file\\-\\\\x31.txt'
-```
-
-Outside of the treatment of `\`, `raw_escape` will function just like [`escape`](#escape):
-
-!!! new "New 8.1"
-    A `raw_escape` variant for `fnmatch` was made available in 8.1.
-
 ### `fnmatch.is_magic` {: #is_magic}
 
 ```py3

--- a/docs/src/markdown/glob.md
+++ b/docs/src/markdown/glob.md
@@ -550,6 +550,19 @@ escaping will be used.
 
 #### `glob.raw_escape` {: #raw_escape}
 
+!!! warning "Deprecated 8.1"
+    In 8.1, `raw_escape` has been deprecated. The same can be accomplished simply by using `codecs` and then using the
+    normal [`escape`](#escape):
+
+    ```pycon3
+    >>> string = r"translate\\raw strings\\\u00c3\xc3\303\N{LATIN CAPITAL LETTER A WITH TILDE}"
+    >>> translated = codecs.decode(string, 'unicode_escape')
+    >>> glob.escape(translated)
+    'translate\\\\raw strings\\\\ÃÃÃÃ'
+    >>> glob.raw_escape(string)
+    'translate\\\\raw strings\\\\ÃÃÃÃ'
+    ```
+
 ```py3
 def raw_escape(pattern, unix=None, raw_chars=True):
 ```

--- a/tests/test_glob.py
+++ b/tests/test_glob.py
@@ -1208,6 +1208,17 @@ class TestGlobEscapes(unittest.TestCase):
                 )
             )
 
+    def test_raw_escape_deprecation(self):
+        """Test raw escape deprecation."""
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+
+            glob.raw_escape(r'test\\test')
+
+            self.assertTrue(len(w) == 1)
+            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
+
     def test_escape(self):
         """Test path escapes."""
 

--- a/wcmatch/glob.py
+++ b/wcmatch/glob.py
@@ -603,6 +603,7 @@ def globfilter(filenames, patterns, *, flags=0, root_dir=None, limit=_wcparse.PA
     return matches
 
 
+@util.deprecated("This function will be removed in 9.0.")
 def raw_escape(pattern, unix=None, raw_chars=True):
     """Apply raw character transform before applying escape."""
 


### PR DESCRIPTION
The same can be accomplished simply by using `codecs.decode(string, 'unicode_escape')` and then using `escape`. Considering that this was added and I've never actually used it, coupled with the fact that this is possible in a fairly trivial manner without this API function, I can't see a need for carrying this around any longer.