### PR TITLE
Remove raw_escape from fnmatch

### DIFF
--- a/tests/test_fnmatch.py
+++ b/tests/test_fnmatch.py
@@ -617,7 +617,7 @@ class TestIsMagic(unittest.TestCase):
 class TestFnMatchEscapes(unittest.TestCase):
     """Test escaping."""
 
-    def check_escape(self, arg, expected, raw=False, unix=None, raw_chars=True):
+    def check_escape(self, arg, expected, unix=None, raw_chars=True):
         """Verify escapes."""
 
         flags = 0
@@ -626,27 +626,15 @@ class TestFnMatchEscapes(unittest.TestCase):
         elif unix is True:
             flags = fnmatch.FORCEUNIX
 
-        if raw:
-            self.assertEqual(fnmatch.raw_escape(arg, raw_chars=raw_chars), expected)
-            self.assertEqual(fnmatch.raw_escape(os.fsencode(arg), raw_chars=raw_chars), os.fsencode(expected))
-            file = (util.norm_pattern(arg, False, True) if raw_chars else arg).replace('\\\\', '\\')
-            self.assertTrue(
-                fnmatch.fnmatch(
-                    file,
-                    fnmatch.raw_escape(arg, raw_chars=raw_chars),
-                    flags=flags
-                )
+        self.assertEqual(fnmatch.escape(arg), expected)
+        self.assertEqual(fnmatch.escape(os.fsencode(arg)), os.fsencode(expected))
+        self.assertTrue(
+            fnmatch.fnmatch(
+                arg,
+                fnmatch.escape(arg),
+                flags=flags
             )
-        else:
-            self.assertEqual(fnmatch.escape(arg), expected)
-            self.assertEqual(fnmatch.escape(os.fsencode(arg)), os.fsencode(expected))
-            self.assertTrue(
-                fnmatch.fnmatch(
-                    arg,
-                    fnmatch.escape(arg),
-                    flags=flags
-                )
-            )
+        )
 
     def test_escape(self):
         """Test path escapes."""
@@ -658,36 +646,6 @@ class TestFnMatchEscapes(unittest.TestCase):
         check('*', r'\*')
         check('[[_/*?*/_]]', r'\[\[_/\*\?\*/_\]\]')
         check('/[[_/*?*/_]]/', r'/\[\[_/\*\?\*/_\]\]/')
-
-    def test_raw_escape(self):
-        """Test path escapes."""
-
-        check = self.check_escape
-        check(r'abc', 'abc', raw=True)
-        check(r'[', r'\[', raw=True)
-        check(r'?', r'\?', raw=True)
-        check(r'*', r'\*', raw=True)
-        check(r'[[_/*?*/_]]', r'\[\[_/\*\?\*/_\]\]', raw=True)
-        check(r'/[[_/*?*/_]]/', r'/\[\[_/\*\?\*/_\]\]/', raw=True)
-        check(r'\x3f', r'\?', raw=True)
-        # `fnmatch` doesn't care about drives
-        check(r'\\\\[^what]\\name\\temp', r'\\\\\[^what\]\\name\\temp', raw=True, unix=False)
-        check('//[^what]/name/temp', r'//\[^what\]/name/temp', raw=True, unix=False)
-
-    def test_raw_escape_no_raw_chars(self):
-        """Test path escapes with no raw character translations."""
-
-        check = self.check_escape
-        check(r'abc', 'abc', raw=True, raw_chars=False)
-        check(r'[', r'\[', raw=True, raw_chars=False)
-        check(r'?', r'\?', raw=True, raw_chars=False)
-        check(r'*', r'\*', raw=True, raw_chars=False)
-        check(r'[[_/*?*/_]]', r'\[\[_/\*\?\*/_\]\]', raw=True, raw_chars=False)
-        check(r'/[[_/*?*/_]]/', r'/\[\[_/\*\?\*/_\]\]/', raw=True, raw_chars=False)
-        check(r'\x3f', r'\\x3f', raw=True, raw_chars=False)
-        # `fnmatch` doesn't care about drives
-        check(r'\\\\[^what]\\name\\temp', r'\\\\\[^what\]\\name\\temp', raw=True, raw_chars=False, unix=False)
-        check('//[^what]/name/temp', r'//\[^what\]/name/temp', raw=True, raw_chars=False, unix=False)
 
     @unittest.skipUnless(sys.platform.startswith('win'), "Windows specific test")
     def test_escape_windows(self):

--- a/wcmatch/_wcparse.py
+++ b/wcmatch/_wcparse.py
@@ -314,20 +314,15 @@ class PatternLimitException(Exception):
     """Pattern limit exception."""
 
 
-def raw_escape(pattern, unix=None, raw_chars=True, pathname=False):
-    """Apply raw character transform before applying escape."""
+def escape(pattern, unix=None, pathname=True, raw=False):
+    """
+    Escape.
 
-    return _escape(util.norm_pattern(pattern, False, raw_chars, True), unix, True, pathname=pathname)
+    `unix`: use Unix style path logic.
+    `pathname`: Use path logic.
+    `raw`: Handle raw strings (deprecated)
 
-
-def escape(pattern, unix=None, pathname=False):
-    """Normal escape."""
-
-    return _escape(pattern, unix, pathname=pathname)
-
-
-def _escape(pattern, unix=None, raw=False, pathname=False):
-    """Escape."""
+    """
 
     if isinstance(pattern, bytes):
         drive_pat = RE_WIN_DRIVE[BYTES]

--- a/wcmatch/fnmatch.py
+++ b/wcmatch/fnmatch.py
@@ -27,7 +27,7 @@ __all__ = (
     "NEGATE", "MINUSNEGATE", "DOTMATCH", "BRACE", "SPLIT",
     "NEGATEALL", "FORCEWIN", "FORCEUNIX",
     "C", "I", "R", "N", "M", "D", "E", "S", "B", "A", "W", "U",
-    "translate", "fnmatch", "filter", "escape", "raw_escape", "is_magic"
+    "translate", "fnmatch", "filter", "escape", "is_magic"
 )
 
 C = CASE = _wcparse.CASE
@@ -105,16 +105,10 @@ def filter(filenames, patterns, *, flags=0, limit=_wcparse.PATTERN_LIMIT):  # no
     return matches
 
 
-def raw_escape(pattern, raw_chars=True):
-    """Apply raw character transform before applying escape."""
-
-    return _wcparse.raw_escape(pattern, raw_chars=raw_chars)
-
-
 def escape(pattern):
     """Escape."""
 
-    return _wcparse.escape(pattern)
+    return _wcparse.escape(pattern, pathname=False)
 
 
 def is_magic(pattern, *, flags=0):

--- a/wcmatch/glob.py
+++ b/wcmatch/glob.py
@@ -620,13 +620,13 @@ def globfilter(filenames, patterns, *, flags=0, root_dir=None, limit=_wcparse.PA
 def raw_escape(pattern, unix=None, raw_chars=True):
     """Apply raw character transform before applying escape."""
 
-    return _wcparse.raw_escape(pattern, unix, raw_chars, pathname=True)
+    return _wcparse.escape(util.norm_pattern(pattern, False, raw_chars, True), unix=unix, pathname=True, raw=True)
 
 
 def escape(pattern, unix=None):
     """Escape."""
 
-    return _wcparse.escape(pattern, unix, pathname=True)
+    return _wcparse.escape(pattern, unix=unix)
 
 
 def is_magic(pattern, *, flags=0):


### PR DESCRIPTION
As we are deprecating raw_escape in glob, there is no reason to release
fnmatch with raw_escape.