### PR TITLE
Fix user handling in tilde test for Windows

### DIFF
--- a/tests/test_glob.py
+++ b/tests/test_glob.py
@@ -1543,9 +1543,15 @@ class TestTilde(unittest.TestCase):
     def test_tilde_user(self):
         """Test tilde user cases."""
 
-        try:
-            user = getpass.getuser()
-        except ModuleNotFoundError:
+        # Accommodate non-Windows user behavior
+        user = None
+        if not sys.platform.startswith('win'):
+            try:
+                user = getpass.getuser()
+            except ModuleNotFoundError:
+                pass
+
+        if user is None:
             user = os.path.basename(os.path.expanduser('~'))
 
         files = os.listdir(os.path.expanduser('~{}'.format(user)))


### PR DESCRIPTION
Recently a fix for the tests related to tilde expansion was added for
Linux. While this behavior accommodated Linux pretty well, in some
cases, on Windows, the fix could cause the test to fail. Only use the
adjustment for non-Windows systems.