### PR TITLE
typos (fnamtch => fnmatch)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ is found where Wildcard Match seems to deviate in an illogical way, we'd love to
 
 A quick overview of Wildcard Match's Features:
 
-- Provides an interface comparable to Python's builtin in `fnamtch`, `glob`, and `pathlib`.
+- Provides an interface comparable to Python's builtin in `fnmatch`, `glob`, and `pathlib`.
 - Allows for a much more configurable experience when matching or globbing with many more features.
 - Adds support for `**` in glob.
 - Adds support for escaping characters with `\`.

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -23,7 +23,7 @@
 
 ## 8.1
 
-- **NEW**: Add `is_magic` function to the `glob` and `fnamtch` library.
+- **NEW**: Add `is_magic` function to the `glob` and `fnmatch` library.
 - **NEW**: `fnmatch` now has `escape` available via its API. The `fnmatch` variant uses filename logic instead of path
   logic.
 - **NEW**: Deprecate `raw_escape` in `glob` as it is very niche and the same can be accomplished simply by using

--- a/docs/src/markdown/fnmatch.md
+++ b/docs/src/markdown/fnmatch.md
@@ -81,9 +81,9 @@ to filter other patterns, not match anything by themselves.
 
 ```pycon3
 >>> from wcmatch import fnmatch
->>> fnmatch.fnmatch('test.py', r'*|!*.py', flags=fnmatch.NEGATE | fnamtch.SPLIT)
+>>> fnmatch.fnmatch('test.py', r'*|!*.py', flags=fnmatch.NEGATE | fnmatch.SPLIT)
 False
->>> fnmatch.fnmatch('test.txt', r'*|!*.py', flags=fnmatch.NEGATE | fnamtch.SPLIT)
+>>> fnmatch.fnmatch('test.txt', r'*|!*.py', flags=fnmatch.NEGATE | fnmatch.SPLIT)
 True
 >>> fnmatch.fnmatch('test.txt', [r'*.txt', r'!avoid.txt'], flags=fnmatch.NEGATE)
 True
@@ -98,9 +98,9 @@ pattern were given: `*` and `!*.md`.
 
 ```pycon3
 >>> from wcmatch import fnmatch
->>> fnmatch.fnmatch('test.py', r'!*.py', flags=fnmatch.NEGATE | fnamtch.NEGATEALL)
+>>> fnmatch.fnmatch('test.py', r'!*.py', flags=fnmatch.NEGATE | fnmatch.NEGATEALL)
 False
->>> fnmatch.fnmatch('test.txt', r'!*.py', flags=fnmatch.NEGATE | fnamtch.NEGATEALL)
+>>> fnmatch.fnmatch('test.txt', r'!*.py', flags=fnmatch.NEGATE | fnmatch.NEGATEALL)
 True
 ```
 

--- a/docs/src/markdown/index.md
+++ b/docs/src/markdown/index.md
@@ -24,7 +24,7 @@ about it in the [issue tracker][issues].
 
 A quick overview of Wildcard Match's Features:
 
-- Provides an interface comparable to Python's builtin in [`fnamtch`][fnmatch], [`glob`][glob], and
+- Provides an interface comparable to Python's builtin in [`fnmatch`][fnmatch], [`glob`][glob], and
   [`pathlib`][pathlib].
 - Allows for a much more configurable experience when matching or globbing with many more features.
 - Adds support for `**` in glob.


### PR DESCRIPTION
A few cases where characters appear to be transposed.