### PR TITLE
Replace use of Optional in type annotations

### DIFF
--- a/wcmatch/_wcmatch.py
+++ b/wcmatch/_wcmatch.py
@@ -5,7 +5,7 @@ import os
 import stat
 import copyreg
 from . import util
-from typing import Pattern, AnyStr, Optional, Generic, Any, cast
+from typing import Pattern, AnyStr, Generic, Any, cast
 
 # `O_DIRECTORY` may not always be defined
 DIR_FLAGS = os.O_RDONLY | getattr(os, 'O_DIRECTORY', 0)
@@ -30,7 +30,7 @@ class _Match(Generic[AnyStr]):
         self,
         filename: AnyStr,
         include: tuple[Pattern[AnyStr], ...],
-        exclude: Optional[tuple[Pattern[AnyStr], ...]],
+        exclude: tuple[Pattern[AnyStr], ...] | None,
         real: bool,
         path: bool,
         follow: bool
@@ -39,7 +39,7 @@ class _Match(Generic[AnyStr]):
 
         self.filename = filename  # type: AnyStr
         self.include = include  # type: tuple[Pattern[AnyStr], ...]
-        self.exclude = exclude  # type: Optional[tuple[Pattern[AnyStr], ...]]
+        self.exclude = exclude  # type: tuple[Pattern[AnyStr], ...] | None
         self.real = real
         self.path = path
         self.follow = follow
@@ -52,9 +52,9 @@ class _Match(Generic[AnyStr]):
         is_dir: bool,
         sep: AnyStr,
         follow: bool,
-        symlinks: dict[tuple[Optional[int], AnyStr], bool],
+        symlinks: dict[tuple[int | None, AnyStr], bool],
         root: AnyStr,
-        dir_fd: Optional[int]
+        dir_fd: int | None
     ) -> bool:
         """
         Match path against the pattern.
@@ -119,9 +119,9 @@ class _Match(Generic[AnyStr]):
 
     def _match_real(
         self,
-        symlinks: dict[tuple[Optional[int], AnyStr], bool],
+        symlinks: dict[tuple[int | None, AnyStr], bool],
         root: AnyStr,
-        dir_fd: Optional[int]
+        dir_fd: int | None
     ) -> bool:
         """Match real filename includes and excludes."""
 
@@ -166,7 +166,7 @@ class _Match(Generic[AnyStr]):
 
         return matched
 
-    def match(self, root_dir: Optional[AnyStr] = None, dir_fd: Optional[int] = None) -> bool:
+    def match(self, root_dir: AnyStr | None = None, dir_fd: int | None = None) -> bool:
         """Match."""
 
         if self.real:
@@ -208,7 +208,7 @@ class _Match(Generic[AnyStr]):
                     exists = True
 
             if exists:
-                symlinks = {}  # type: dict[tuple[Optional[int], AnyStr], bool]
+                symlinks = {}  # type: dict[tuple[int | None, AnyStr], bool]
                 return self._match_real(symlinks, root, dir_fd)
             else:
                 return False
@@ -233,7 +233,7 @@ class WcRegexp(util.Immutable, Generic[AnyStr]):
     """File name match object."""
 
     _include: tuple[Pattern[AnyStr], ...]
-    _exclude: Optional[tuple[Pattern[AnyStr], ...]]
+    _exclude: tuple[Pattern[AnyStr], ...] | None
     _real: bool
     _path: bool
     _follow: bool
@@ -244,7 +244,7 @@ class WcRegexp(util.Immutable, Generic[AnyStr]):
     def __init__(
         self,
         include: tuple[Pattern[AnyStr], ...],
-        exclude: Optional[tuple[Pattern[AnyStr], ...]] = None,
+        exclude: tuple[Pattern[AnyStr], ...] | None = None,
         real: bool = False,
         path: bool = False,
         follow: bool = False
@@ -303,7 +303,7 @@ class WcRegexp(util.Immutable, Generic[AnyStr]):
             self._follow != other._follow
         )
 
-    def match(self, filename: AnyStr, root_dir: Optional[AnyStr] = None, dir_fd: Optional[int] = None) -> bool:
+    def match(self, filename: AnyStr, root_dir: AnyStr | None = None, dir_fd: int | None = None) -> bool:
         """Match filename."""
 
         return _Match(

--- a/wcmatch/_wcparse.py
+++ b/wcmatch/_wcparse.py
@@ -7,7 +7,7 @@ import os
 from . import util
 from . import posix
 from . _wcmatch import WcRegexp
-from typing import AnyStr, Iterable, Pattern, Generic, Optional, Sequence, overload, cast
+from typing import AnyStr, Iterable, Pattern, Generic, Sequence, overload, cast
 
 UNICODE_RANGE = '\u0000-\U0010ffff'
 ASCII_RANGE = '\x00-\xff'
@@ -300,7 +300,7 @@ def iter_patterns(patterns: AnyStr | Sequence[AnyStr]) -> Iterable[AnyStr]:
         yield from patterns
 
 
-def escape(pattern: AnyStr, unix: Optional[bool] = None, pathname: bool = True, raw: bool = False) -> AnyStr:
+def escape(pattern: AnyStr, unix: bool | None = None, pathname: bool = True, raw: bool = False) -> AnyStr:
     """
     Escape.
 
@@ -351,7 +351,7 @@ def _get_win_drive(
     pattern: str,
     regex: bool = False,
     case_sensitive: bool = False
-) -> tuple[bool, Optional[str], bool, int]:
+) -> tuple[bool, str | None, bool, int]:
     """Get Windows drive."""
 
     drive = None
@@ -599,7 +599,7 @@ def translate(
     patterns: str | Sequence[str],
     flags: int,
     limit: int = PATTERN_LIMIT,
-    exclude: Optional[str | Sequence[str]] = None
+    exclude: str | Sequence[str] | None = None
 ) -> tuple[list[str], list[str]]:
     ...
 
@@ -609,7 +609,7 @@ def translate(
     patterns: bytes | Sequence[bytes],
     flags: int,
     limit: int = PATTERN_LIMIT,
-    exclude: Optional[bytes | Sequence[bytes]] = None
+    exclude: bytes | Sequence[bytes] | None = None
 ) -> tuple[list[bytes], list[bytes]]:
     ...
 
@@ -618,7 +618,7 @@ def translate(
     patterns: AnyStr | Sequence[AnyStr],
     flags: int,
     limit: int = PATTERN_LIMIT,
-    exclude: Optional[AnyStr | Sequence[AnyStr]] = None
+    exclude: AnyStr | Sequence[AnyStr] | None = None
 ) -> tuple[list[AnyStr], list[AnyStr]]:
     """Translate patterns."""
 
@@ -685,7 +685,7 @@ def compile_pattern(
     patterns: str | Sequence[str],
     flags: int,
     limit: int = PATTERN_LIMIT,
-    exclude: Optional[str | Sequence[str]] = None
+    exclude: str | Sequence[str] | None = None
 ) -> tuple[list[Pattern[str]], list[Pattern[str]]]:
     ...
 
@@ -695,7 +695,7 @@ def compile_pattern(
     patterns: bytes | Sequence[bytes],
     flags: int,
     limit: int = PATTERN_LIMIT,
-    exclude: Optional[bytes | Sequence[bytes]] = None
+    exclude: bytes | Sequence[bytes] | None = None
 ) -> tuple[list[Pattern[bytes]], list[Pattern[bytes]]]:
     ...
 
@@ -704,7 +704,7 @@ def compile_pattern(
     patterns: AnyStr | Sequence[AnyStr],
     flags: int,
     limit: int = PATTERN_LIMIT,
-    exclude: Optional[AnyStr | Sequence[AnyStr]] = None
+    exclude: AnyStr | Sequence[AnyStr] | None = None
 ) -> tuple[list[Pattern[AnyStr]], list[Pattern[AnyStr]]]:
     """Compile the patterns."""
 
@@ -759,7 +759,7 @@ def compile(  # noqa: A001
     patterns: str | Sequence[str],
     flags: int,
     limit: int = PATTERN_LIMIT,
-    exclude: Optional[str | Sequence[str]] = None
+    exclude: str | Sequence[str] | None = None
 ) -> WcRegexp[str]:
     ...
 
@@ -769,7 +769,7 @@ def compile(  # noqa: A001
     patterns: bytes | Sequence[bytes],
     flags: int,
     limit: int = PATTERN_LIMIT,
-    exclude: Optional[bytes | Sequence[bytes]] = None
+    exclude: bytes | Sequence[bytes] | None = None
 ) -> WcRegexp[bytes]:
     ...
 
@@ -778,7 +778,7 @@ def compile(  # noqa: A001
     patterns: AnyStr | Sequence[AnyStr],
     flags: int,
     limit: int = PATTERN_LIMIT,
-    exclude: Optional[AnyStr | Sequence[AnyStr]] = None
+    exclude: AnyStr | Sequence[AnyStr] | None = None
 ) -> WcRegexp[AnyStr]:
     """Compile patterns."""
 

--- a/wcmatch/fnmatch.py
+++ b/wcmatch/fnmatch.py
@@ -5,7 +5,7 @@ A custom implementation of `fnmatch`.
 """
 from __future__ import annotations
 from . import _wcparse
-from typing import AnyStr, Iterable, Sequence, Optional
+from typing import AnyStr, Iterable, Sequence
 
 __all__ = (
     "CASE", "EXTMATCH", "IGNORECASE", "RAWCHARS",
@@ -59,7 +59,7 @@ def translate(
     *,
     flags: int = 0,
     limit: int = _wcparse.PATTERN_LIMIT,
-    exclude: Optional[AnyStr | Sequence[AnyStr]] = None
+    exclude: AnyStr | Sequence[AnyStr] | None = None
 ) -> tuple[list[AnyStr], list[AnyStr]]:
     """Translate `fnmatch` pattern."""
 
@@ -73,7 +73,7 @@ def fnmatch(
     *,
     flags: int = 0,
     limit: int = _wcparse.PATTERN_LIMIT,
-    exclude: Optional[AnyStr | Sequence[AnyStr]] = None
+    exclude: AnyStr | Sequence[AnyStr] | None = None
 ) -> bool:
     """
     Check if filename matches pattern.
@@ -92,7 +92,7 @@ def filter(  # noqa A001
     *,
     flags: int = 0,
     limit: int = _wcparse.PATTERN_LIMIT,
-    exclude: Optional[AnyStr | Sequence[AnyStr]] = None
+    exclude: AnyStr | Sequence[AnyStr] | None = None
 ) -> list[AnyStr]:
     """Filter names using pattern."""
 

--- a/wcmatch/glob.py
+++ b/wcmatch/glob.py
@@ -13,10 +13,7 @@ import bracex
 from . import _wcparse
 from . import _wcmatch
 from . import util
-from typing import (
-    Optional, Iterator, Iterable, AnyStr, Generic,
-    Pattern, Callable, Any, Sequence, cast
-)
+from typing import Iterator, Iterable, AnyStr, Generic, Pattern, Callable, Any, Sequence, cast
 
 __all__ = (
     "CASE", "IGNORECASE", "RAWCHARS", "DOTGLOB", "DOTMATCH",
@@ -381,10 +378,10 @@ class Glob(Generic[AnyStr]):
         self,
         pattern: AnyStr | Sequence[AnyStr],
         flags: int = 0,
-        root_dir: Optional[AnyStr | 'os.PathLike[AnyStr]'] = None,
-        dir_fd: Optional[int] = None,
+        root_dir: AnyStr | os.PathLike[AnyStr] | None = None,
+        dir_fd: int | None = None,
         limit: int = _wcparse.PATTERN_LIMIT,
-        exclude: Optional[AnyStr | Sequence[AnyStr]] = None
+        exclude: AnyStr | Sequence[AnyStr] | None = None
     ) -> None:
         """Initialize the directory walker object."""
 
@@ -397,7 +394,7 @@ class Glob(Generic[AnyStr]):
         self.pattern = []  # type: list[list[_GlobPart]]
         self.npatterns = []  # type: list[Pattern[AnyStr]]
         self.seen = set()  # type: set[AnyStr]
-        self.dir_fd = dir_fd if SUPPORT_DIR_FD else None  # type: Optional[int]
+        self.dir_fd = dir_fd if SUPPORT_DIR_FD else None  # type: int | None
         self.nounique = bool(flags & NOUNIQUE)  # type: bool
         self.mark = bool(flags & MARK)  # type: bool
         # Only scan for `.` and `..` if it is specifically requested.
@@ -566,16 +563,16 @@ class Glob(Generic[AnyStr]):
 
         return bool(self.npatterns and self._match_excluded(path, is_dir))
 
-    def _match_literal(self, a: AnyStr, b: Optional[AnyStr] = None) -> bool:
+    def _match_literal(self, a: AnyStr, b: AnyStr | None = None) -> bool:
         """Match two names."""
 
         return a.lower() == b if not self.case_sensitive else a == b
 
-    def _get_matcher(self, target: Optional[AnyStr | Pattern[AnyStr]]) -> Optional[Callable[..., Any]]:
+    def _get_matcher(self, target: AnyStr | Pattern[AnyStr] | None) -> Callable[..., Any] | None:
         """Get deep match."""
 
         if target is None:
-            matcher = None  # type: Optional[Callable[..., Any]]
+            matcher = None  # type: Callable[..., Any] | None
         elif isinstance(target, (str, bytes)):
             # Plain text match
             if not self.case_sensitive:
@@ -608,11 +605,11 @@ class Glob(Generic[AnyStr]):
         else:
             return os.path.join(self.root_dir, path)
 
-    def _iter(self, curdir: Optional[AnyStr], dir_only: bool, deep: bool) -> Iterator[tuple[AnyStr, bool, bool, bool]]:
+    def _iter(self, curdir: AnyStr | None, dir_only: bool, deep: bool) -> Iterator[tuple[AnyStr, bool, bool, bool]]:
         """Iterate the directory."""
 
         try:
-            fd = None  # type: Optional[int]
+            fd = None  # type: int | None
             if self.is_abs_pattern and curdir:
                 scandir = curdir  # type: AnyStr | int
             elif self.dir_fd is not None:
@@ -653,7 +650,7 @@ class Glob(Generic[AnyStr]):
     def _glob_dir(
         self,
         curdir: AnyStr,
-        matcher: Optional[Callable[..., Any]],
+        matcher: Callable[..., Any] | None,
         dir_only: bool = False,
         deep: bool = False
     ) -> Iterator[tuple[AnyStr, bool]]:
@@ -852,10 +849,10 @@ def iglob(
     patterns: AnyStr | Sequence[AnyStr],
     *,
     flags: int = 0,
-    root_dir: Optional[AnyStr | os.PathLike[AnyStr]] = None,
-    dir_fd: Optional[int] = None,
+    root_dir: AnyStr | os.PathLike[AnyStr] | None = None,
+    dir_fd: int | None = None,
     limit: int = _wcparse.PATTERN_LIMIT,
-    exclude: Optional[AnyStr | Sequence[AnyStr]] = None
+    exclude: AnyStr | Sequence[AnyStr] | None = None
 ) -> Iterator[AnyStr]:
     """Glob."""
 
@@ -869,10 +866,10 @@ def glob(
     patterns: AnyStr | Sequence[AnyStr],
     *,
     flags: int = 0,
-    root_dir: Optional[AnyStr | os.PathLike[AnyStr]] = None,
-    dir_fd: Optional[int] = None,
+    root_dir: AnyStr | os.PathLike[AnyStr] | None = None,
+    dir_fd: int | None = None,
     limit: int = _wcparse.PATTERN_LIMIT,
-    exclude: Optional[AnyStr | Sequence[AnyStr]] = None
+    exclude: AnyStr | Sequence[AnyStr] | None = None
 ) -> list[AnyStr]:
     """Glob."""
 
@@ -884,7 +881,7 @@ def translate(
     *,
     flags: int = 0,
     limit: int = _wcparse.PATTERN_LIMIT,
-    exclude: Optional[AnyStr | Sequence[AnyStr]] = None
+    exclude: AnyStr | Sequence[AnyStr] | None = None
 ) -> tuple[list[AnyStr], list[AnyStr]]:
     """Translate glob pattern."""
 
@@ -897,10 +894,10 @@ def globmatch(
     patterns: AnyStr | Sequence[AnyStr],
     *,
     flags: int = 0,
-    root_dir: Optional[AnyStr | os.PathLike[AnyStr]] = None,
-    dir_fd: Optional[int] = None,
+    root_dir: AnyStr | os.PathLike[AnyStr] | None = None,
+    dir_fd: int | None = None,
     limit: int = _wcparse.PATTERN_LIMIT,
-    exclude: Optional[AnyStr | Sequence[AnyStr]] = None
+    exclude: AnyStr | Sequence[AnyStr] | None = None
 ) -> bool:
     """
     Check if filename matches pattern.
@@ -925,10 +922,10 @@ def globfilter(
     patterns: AnyStr | Sequence[AnyStr],
     *,
     flags: int = 0,
-    root_dir: Optional[AnyStr | os.PathLike[AnyStr]] = None,
-    dir_fd: Optional[int] = None,
+    root_dir: AnyStr | os.PathLike[AnyStr] | None = None,
+    dir_fd: int | None = None,
     limit: int = _wcparse.PATTERN_LIMIT,
-    exclude: Optional[AnyStr | Sequence[AnyStr]] = None
+    exclude: AnyStr | Sequence[AnyStr] | None = None
 ) -> list[AnyStr | os.PathLike[AnyStr]]:
     """Filter names using pattern."""
 
@@ -950,7 +947,7 @@ def globfilter(
 
 
 @util.deprecated("This function will be removed in 9.0.")
-def raw_escape(pattern: AnyStr, unix: Optional[bool] = None, raw_chars: bool = True) -> AnyStr:
+def raw_escape(pattern: AnyStr, unix: bool | None = None, raw_chars: bool = True) -> AnyStr:
     """Apply raw character transform before applying escape."""
 
     return _wcparse.escape(
@@ -958,7 +955,7 @@ def raw_escape(pattern: AnyStr, unix: Optional[bool] = None, raw_chars: bool = T
     )
 
 
-def escape(pattern: AnyStr, unix: Optional[bool] = None) -> AnyStr:
+def escape(pattern: AnyStr, unix: bool | None = None) -> AnyStr:
     """Escape."""
 
     return _wcparse.escape(pattern, unix=unix)

--- a/wcmatch/pathlib.py
+++ b/wcmatch/pathlib.py
@@ -5,7 +5,7 @@ import os
 from . import glob
 from . import _wcparse
 from . import util
-from typing import Iterable, Any, Sequence, Optional, cast
+from typing import Iterable, Any, Sequence, cast
 
 __all__ = (
     "CASE", "IGNORECASE", "RAWCHARS", "DOTGLOB", "DOTMATCH",
@@ -114,7 +114,7 @@ class PurePath(pathlib.PurePath):
         *,
         flags: int = 0,
         limit: int = _wcparse.PATTERN_LIMIT,
-        exclude: Optional[str | Sequence[str]] = None
+        exclude: str | Sequence[str] | None = None
     ) -> bool:
         """
         Match patterns using `globmatch`, but also using the same right to left logic that the default `pathlib` uses.
@@ -134,7 +134,7 @@ class PurePath(pathlib.PurePath):
         *,
         flags: int = 0,
         limit: int = _wcparse.PATTERN_LIMIT,
-        exclude: Optional[str | Sequence[str]] = None
+        exclude: str | Sequence[str] | None = None
     ) -> bool:
         """
         Match patterns using `globmatch`, but without the right to left logic that the default `pathlib` uses.
@@ -178,7 +178,7 @@ class Path(pathlib.Path):
         *,
         flags: int = 0,
         limit: int = _wcparse.PATTERN_LIMIT,
-        exclude: Optional[str | Sequence[str]] = None
+        exclude: str | Sequence[str] | None = None
     ) -> Iterable['Path']:
         """
         Search the file system.
@@ -201,7 +201,7 @@ class Path(pathlib.Path):
         *,
         flags: int = 0,
         limit: int = _wcparse.PATTERN_LIMIT,
-        exclude: Optional[str | Sequence[str]] = None
+        exclude: str | Sequence[str] | None = None
     ) -> Iterable['Path']:
         """
         Recursive glob.

--- a/wcmatch/util.py
+++ b/wcmatch/util.py
@@ -7,7 +7,7 @@ import re
 import unicodedata
 from functools import wraps
 import warnings
-from typing import Any, Callable, AnyStr, Match, Pattern, Optional, cast
+from typing import Any, Callable, AnyStr, Match, Pattern, cast
 
 PY310 = (3, 10) <= sys.version_info
 
@@ -76,7 +76,7 @@ def is_case_sensitive() -> bool:
     return CASE_FS
 
 
-def norm_pattern(pattern: AnyStr, normalize: Optional[bool], is_raw_chars: bool, ignore_escape: bool = False) -> AnyStr:
+def norm_pattern(pattern: AnyStr, normalize: bool | None, is_raw_chars: bool, ignore_escape: bool = False) -> AnyStr:
     r"""
     Normalize pattern.
 
@@ -147,7 +147,7 @@ class StringIter:
 
         return self.iternext()
 
-    def match(self, pattern: Pattern[str]) -> Optional[Match[str]]:
+    def match(self, pattern: Pattern[str]) -> Match[str] | None:
         """Perform regex match at index."""
 
         m = pattern.match(self._string, self._index)

--- a/wcmatch/wcmatch.py
+++ b/wcmatch/wcmatch.py
@@ -9,7 +9,7 @@ import re
 from . import _wcparse
 from . import _wcmatch
 from . import util
-from typing import Optional, Any, Iterator, Generic, AnyStr
+from typing import Any, Iterator, Generic, AnyStr
 
 
 __all__ = (
@@ -71,8 +71,8 @@ class WcMatch(Generic[AnyStr]):
     def __init__(
         self,
         root_dir: AnyStr,
-        file_pattern: Optional[AnyStr] = None,
-        exclude_pattern: Optional[AnyStr] = None,
+        file_pattern: AnyStr | None = None,
+        exclude_pattern: AnyStr | None = None,
         flags: int = 0,
         limit: int = _wcparse.PATHNAME,
         **kwargs: Any
@@ -90,8 +90,8 @@ class WcMatch(Generic[AnyStr]):
         empty = os.fsencode('') if isinstance(root_dir, bytes) else ''
         self.pattern_file = file_pattern if file_pattern is not None else empty  # type: AnyStr
         self.pattern_folder_exclude = exclude_pattern if exclude_pattern is not None else empty  # type: AnyStr
-        self.file_check = None  # type: Optional[_wcmatch.WcRegexp[AnyStr]]
-        self.folder_exclude_check = None  # type: Optional[_wcmatch.WcRegexp[AnyStr]]
+        self.file_check = None  # type: _wcmatch.WcRegexp[AnyStr] | None
+        self.folder_exclude_check = None  # type: _wcmatch.WcRegexp[AnyStr] | None
         self.on_init(**kwargs)
         self._compile(self.pattern_file, self.pattern_folder_exclude)
 
@@ -135,7 +135,7 @@ class WcMatch(Generic[AnyStr]):
             self.flags |= _FORCEWIN
         self.flags = self.flags & (_wcparse.FLAG_MASK ^ MATCHBASE)
 
-    def _compile_wildcard(self, pattern: AnyStr, pathname: bool = False) -> Optional[_wcmatch.WcRegexp[AnyStr]]:
+    def _compile_wildcard(self, pattern: AnyStr, pathname: bool = False) -> _wcmatch.WcRegexp[AnyStr] | None:
         """Compile or format the wildcard inclusion/exclusion pattern."""
 
         flags = self.flags


### PR DESCRIPTION
Since we use `from __future__ import annotations` type annotations will be ignored as strings. We can use `type | None` even on older Python versions.