### PR TITLE
Fix wcmatch docs: SYMLINK => SYMLINKS

### DIFF
--- a/docs/src/markdown/wcmatch.md
+++ b/docs/src/markdown/wcmatch.md
@@ -310,9 +310,9 @@ is called on every new [`match`](#match) call.
 `HIDDEN` enables the crawling of hidden directories and will return hidden files if the wildcard pattern matches. This
 enables not just dot files, but system hidden files as well.
 
-#### `wcmatch.SYMLINK, wcmatch.SL` {: #symlink}
+#### `wcmatch.SYMLINKS, wcmatch.SL` {: #symlinks}
 
-`SYMLINK` enables the crawling of symlink directories. By default, symlink directories are ignored during the file
+`SYMLINKS` enables the crawling of symlink directories. By default, symlink directories are ignored during the file
 crawl.
 
 #### `wcmatch.CASE, wcmatch.C` {: #case}


### PR DESCRIPTION
According to the source code, the doc misses a "S".
https://github.com/jfcherng/wcmatch/blob/24bf989afb8b0a69bba22877ecf2dd832fdd8637/wcmatch/wcmatch.py#L35