### PR TITLE
Add support for Py 3.13

### DIFF
--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 9.0
+
+-   **NEW**: Remove deprecated function `glob.raw_escape`.
+-   **NEW**: Officially support Python 3.13.
+
 ## 8.5.2
 
 -   **FIX**: Fix `pathlib` issue with inheritance on Python versions greater than 3.12.

--- a/docs/src/markdown/fnmatch.md
+++ b/docs/src/markdown/fnmatch.md
@@ -203,7 +203,7 @@ Translate patterns now provide capturing groups for [`EXTMATCH`](#extmatch) grou
 def escape(pattern):
 ```
 
-The `escape` function will conservatively escape `-`, `!`, `*`, `?`, `(`, `)`, `[`, `]`, `|`, `{`, `}`. and `\` with
+The `escape` function will conservatively escape `-`, `!`, `*`, `?`, `(`, `)`, `[`, `]`, `|`, `{`, `}`, and `\` with
 backslashes, regardless of what feature is or is not enabled. It is meant to escape filenames.
 
 ```pycon3

--- a/docs/src/markdown/glob.md
+++ b/docs/src/markdown/glob.md
@@ -600,7 +600,7 @@ Translate patterns now provide capturing groups for [`EXTGLOB`](#extglob) groups
 def escape(pattern, unix=None):
 ```
 
-The `escape` function will conservatively escape `-`, `!`, `*`, `?`, `(`, `)`, `[`, `]`, `|`, `{`, `}`. and `\` with
+The `escape` function will conservatively escape `-`, `!`, `*`, `?`, `(`, `)`, `[`, `]`, `|`, `{`, `}`, and `\` with
 backslashes, regardless of what feature is or is not enabled. It is meant to escape path parts (filenames, Windows
 drives, UNC sharepoints) or full paths.
 
@@ -658,90 +658,6 @@ force Windows style escaping.
 /// new | New 7.0
 `{`, `}`, and `|` will be escaped in Windows drives. Additionally, users can escape these characters in Windows
 drives manually in their match patterns as well.
-///
-
-#### `glob.raw_escape` {: #raw_escape}
-
-/// warning | Deprecated 8.1
-In 8.1, `raw_escape` has been deprecated. The same can be accomplished simply by using `codecs` and then using the
-normal [`escape`](#escape):
-
-```pycon3
->>> string = r"translate\\raw strings\\\u00c3\xc3\303\N{LATIN CAPITAL LETTER A WITH TILDE}"
->>> translated = codecs.decode(string, 'unicode_escape')
->>> glob.escape(translated)
-'translate\\\\raw strings\\\\ÃÃÃÃ'
->>> glob.raw_escape(string)
-'translate\\\\raw strings\\\\ÃÃÃÃ'
-```
-///
-
-```py3
-def raw_escape(pattern, unix=None, raw_chars=True):
-```
-
-`raw_escape` is kind of a niche function and 99% of the time, it is recommended to use [`escape`](#escape).
-
-The big difference between `raw_escape` and [`escape`](#escape) is how `\` are handled. `raw_escape` is mainly for paths
-provided to Python via an interface that doesn't process Python strings like they normally are, for instance an input
-in a GUI.
-
-To illustrate, you may have an interface to input path names, but may want to take advantage of Python Unicode
-references. Normally, on a python command line, you can do this:
-
-```pycon3
->>> 'folder\\El Ni\u00f1o'
-'folder\\El Niño'
-```
-
-But when in a GUI interface, if a user inputs the same, it's like getting a raw string.
-
-```pycon3
->>> r'folder\\El Ni\u00f1o'
-'folder\\\\El Ni\\u00f1o'
-```
-
-`raw_escape` will take a raw string in the above format and resolve character escapes and escape the path as if it was
-a normal string.  Notice to do this, we must treat literal Windows' path backslashes as an escaped backslash.
-
-```pycon3
->>> glob.escape('folder\\El Ni\u00f1o', unix=False)
-'folder\\\\El Niño'
->>> glob.raw_escape(r'folder\\El Ni\u00f1o')
-'folder\\\\El Niño'
-```
-
-Handling of raw character references can be turned off if desired:
-
-```pycon3
->>> glob.raw_escape(r'my\\file-\x31.txt', unix=False)
-'my\\\\file\\-1.txt'
->>> glob.raw_escape(r'my\\file-\x31.txt', unix=False, raw_chars=False)
-'my\\\\file\\-\\\\x31.txt'
-```
-
-Outside of the treatment of `\`, `raw_escape` will function just like [`escape`](#escape):
-
-`raw_escape` will detect the system it is running on and pick Windows escape logic or Linux/Unix logic. Since
-[`globmatch`](#globmatch) allows you to match Unix style paths on a Windows system, and vice versa, you can force
-Unix style escaping or Windows style escaping via the `unix` parameter. When `unix` is `None`, the escape style will be
-detected, when `unix` is `True` Linux/Unix style escaping will be used, and when `unix` is `False` Windows style
-escaping will be used.
-
-```pycon3
->>> glob.raw_escape(r'some/path?/\x2a\x2afile\x2a\x2a{}.txt', unix=True)
-```
-
-/// new | New 5.0
-The `unix` parameter is now `None` by default. Set to `True` to force Linux/Unix style escaping or set to `False` to
-force Windows style escaping.
-///
-
-/// new | New 7.0
-`{`, `}`, and `|` will be escaped in Windows drives. Additionally, users can escape these characters in Windows
-drives manually in their match patterns as well.
-
-`raw_chars` option was added.
 ///
 
 ### `glob.is_magic` {: #is_magic}

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -33,6 +33,7 @@ class CustomMetadataHook(MetadataHookInterface):
             'Programming Language :: Python :: 3.10',
             'Programming Language :: Python :: 3.11',
             'Programming Language :: Python :: 3.12',
+            'Programming Language :: Python :: 3.13',
             'Topic :: Software Development :: Libraries :: Python Modules',
             'Typing :: Typed'
         ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,7 +111,7 @@ legacy_tox_ini = """
 isolated_build = true
 skipsdist=true
 envlist=
-    py38,py39,py310,py311,py312,
+    py38,py39,py310,py311,py312,py313,
     lint
 
 [testenv]

--- a/wcmatch/__meta__.py
+++ b/wcmatch/__meta__.py
@@ -1,6 +1,5 @@
 """Meta related things."""
 from __future__ import annotations
-from __future__ import unicode_literals
 from collections import namedtuple
 import re
 
@@ -94,7 +93,7 @@ class Version(namedtuple("Version", ["major", "minor", "micro", "release", "pre"
                 raise ValueError("All version parts except 'release' should be integers.")
 
         if release not in REL_MAP:
-            raise ValueError("'{}' is not a valid release type.".format(release))
+            raise ValueError(f"'{release}' is not a valid release type.")
 
         # Ensure valid pre-release (we do not allow implicit pre-releases).
         if ".dev-candidate" < release < "final":
@@ -119,7 +118,7 @@ class Version(namedtuple("Version", ["major", "minor", "micro", "release", "pre"
             elif dev:
                 raise ValueError("Version is not a development release.")
 
-        return super(Version, cls).__new__(cls, major, minor, micro, release, pre, post, dev)
+        return super().__new__(cls, major, minor, micro, release, pre, post, dev)
 
     def _is_pre(self) -> bool:
         """Is prerelease."""
@@ -146,15 +145,15 @@ class Version(namedtuple("Version", ["major", "minor", "micro", "release", "pre"
 
         # Assemble major, minor, micro version and append `pre`, `post`, or `dev` if needed..
         if self.micro == 0:
-            ver = "{}.{}".format(self.major, self.minor)
+            ver = f"{self.major}.{self.minor}"
         else:
-            ver = "{}.{}.{}".format(self.major, self.minor, self.micro)
+            ver = f"{self.major}.{self.minor}.{self.micro}"
         if self._is_pre():
-            ver += '{}{}'.format(REL_MAP[self.release], self.pre)
+            ver += f'{REL_MAP[self.release]}{self.pre}'
         if self._is_post():
-            ver += ".post{}".format(self.post)
+            ver += f".post{self.post}"
         if self._is_dev():
-            ver += ".dev{}".format(self.dev)
+            ver += f".dev{self.dev}"
 
         return ver
 
@@ -165,7 +164,7 @@ def parse_version(ver: str) -> Version:
     m = RE_VER.match(ver)
 
     if m is None:
-        raise ValueError("'{}' is not a valid version".format(ver))
+        raise ValueError(f"'{ver}' is not a valid version")
 
     # Handle major, minor, micro
     major = int(m.group('major'))
@@ -194,5 +193,5 @@ def parse_version(ver: str) -> Version:
     return Version(major, minor, micro, release, pre, post, dev)
 
 
-__version_info__ = Version(8, 5, 2, "final")
+__version_info__ = Version(9, 0, 0, "final")
 __version__ = __version_info__._get_canonical()

--- a/wcmatch/_wcmatch.py
+++ b/wcmatch/_wcmatch.py
@@ -5,7 +5,7 @@ import os
 import stat
 import copyreg
 from . import util
-from typing import Pattern, AnyStr, Generic, Any, cast
+from typing import Pattern, AnyStr, Generic, Any
 
 # `O_DIRECTORY` may not always be defined
 DIR_FLAGS = os.O_RDONLY | getattr(os, 'O_DIRECTORY', 0)
@@ -192,7 +192,7 @@ class _Match(Generic[AnyStr]):
                     )
                 )
 
-            re_mount = cast(Pattern[AnyStr], (RE_WIN_MOUNT if util.platform() == "windows" else RE_MOUNT)[self.ptype])
+            re_mount = (RE_WIN_MOUNT if util.platform() == "windows" else RE_MOUNT)[self.ptype]  # type: Pattern[AnyStr]  # type: ignore[assignment]
             is_abs = re_mount.match(self.filename) is not None
 
             if is_abs:

--- a/wcmatch/pathlib.py
+++ b/wcmatch/pathlib.py
@@ -172,13 +172,13 @@ class Path(pathlib.Path):
             else:
                 self = cls._from_parts(args, init=False)  # type: ignore[attr-defined]
             if not self._flavour.is_supported:
-                raise NotImplementedError("Cannot instantiate {!r} on your system".format(cls.__name__))
+                raise NotImplementedError(f"Cannot instantiate {cls.__name__!r} on your system")
             if not util.PY310:
                 self._init()
             return self  # type: ignore[no-any-return]
         else:
             if cls is WindowsPath and not win_host or cls is not WindowsPath and win_host:
-                raise NotImplementedError("Cannot instantiate {!r} on your system".format(cls.__name__))
+                raise NotImplementedError(f"Cannot instantiate {cls.__name__!r} on your system")
             return object.__new__(cls)
 
     def glob(  # type: ignore[override]

--- a/wcmatch/posix.py
+++ b/wcmatch/posix.py
@@ -73,4 +73,4 @@ def get_posix_property(value: str, limit_ascii: bool = False) -> str:
         else:
             return unicode_posix_properties[value]
     except Exception as e:  # pragma: no cover
-        raise ValueError("'{} is not a valid posix property".format(value)) from e
+        raise ValueError(f"'{value} is not a valid posix property") from e

--- a/wcmatch/util.py
+++ b/wcmatch/util.py
@@ -78,7 +78,7 @@ def is_case_sensitive() -> bool:
     return CASE_FS
 
 
-def norm_pattern(pattern: AnyStr, normalize: bool | None, is_raw_chars: bool, ignore_escape: bool = False) -> AnyStr:
+def norm_pattern(pattern: AnyStr, normalize: bool | None, is_raw_chars: bool) -> AnyStr:
     r"""
     Normalize pattern.
 
@@ -99,7 +99,7 @@ def norm_pattern(pattern: AnyStr, normalize: bool | None, is_raw_chars: bool, ig
         multi_slash = slash * 4
         pat = RE_NORM
 
-    if not normalize and not is_raw_chars and not ignore_escape:
+    if not normalize and not is_raw_chars:
         return pattern
 
     def norm(m: Match[AnyStr]) -> AnyStr:
@@ -119,8 +119,6 @@ def norm_pattern(pattern: AnyStr, normalize: bool | None, is_raw_chars: bool, ig
             char = unicodedata.lookup(m.group(5)[3:-1])
         elif not is_raw_chars or m.group(5 if is_bytes else 6):
             char = m.group(0)
-            if ignore_escape:
-                char = slash + char
         else:
             value = m.group(6) if is_bytes else m.group(7)
             pos = m.start(6) if is_bytes else m.start(7)

--- a/wcmatch/util.py
+++ b/wcmatch/util.py
@@ -7,7 +7,7 @@ import re
 import unicodedata
 from functools import wraps
 import warnings
-from typing import Any, Callable, AnyStr, Match, Pattern, cast
+from typing import Any, Callable, AnyStr, Match, Pattern
 
 PY310 = (3, 10) <= sys.version_info
 PY312 = (3, 12) <= sys.version_info
@@ -110,11 +110,11 @@ def norm_pattern(pattern: AnyStr, normalize: bool | None, is_raw_chars: bool, ig
             if normalize and len(char) > 1:
                 char = multi_slash
         elif m.group(2):
-            char = cast(AnyStr, BACK_SLASH_TRANSLATION[m.group(2)] if is_raw_chars else m.group(2))
+            char = BACK_SLASH_TRANSLATION[m.group(2)] if is_raw_chars else m.group(2)
         elif is_raw_chars and m.group(4):
-            char = cast(AnyStr, bytes([int(m.group(4), 8) & 0xFF]) if is_bytes else chr(int(m.group(4), 8)))
+            char = bytes([int(m.group(4), 8) & 0xFF]) if is_bytes else chr(int(m.group(4), 8))
         elif is_raw_chars and m.group(3):
-            char = cast(AnyStr, bytes([int(m.group(3)[2:], 16)]) if is_bytes else chr(int(m.group(3)[2:], 16)))
+            char = bytes([int(m.group(3)[2:], 16)]) if is_bytes else chr(int(m.group(3)[2:], 16))
         elif is_raw_chars and not is_bytes and m.group(5):
             char = unicodedata.lookup(m.group(5)[3:-1])
         elif not is_raw_chars or m.group(5 if is_bytes else 6):
@@ -124,7 +124,7 @@ def norm_pattern(pattern: AnyStr, normalize: bool | None, is_raw_chars: bool, ig
         else:
             value = m.group(6) if is_bytes else m.group(7)
             pos = m.start(6) if is_bytes else m.start(7)
-            raise SyntaxError("Could not convert character value {!r} at position {:d}".format(value, pos))
+            raise SyntaxError(f"Could not convert character value {value!r} at position {pos:d}")
         return char
 
     return pat.sub(norm, pattern)


### PR DESCRIPTION
- Support Py 3.13
- Remove deprecated `raw_escape`
- Remove casting which incurs a performance cost for little gain. Once that cannot easily be resolved, just ignore the mypy error.
- Update formatted strings to f-string (where possible)