### PR TITLE
More efficient EXTGLOB/EXTMATCH handling

### DIFF
--- a/docs/src/dictionary/en-custom.txt
+++ b/docs/src/dictionary/en-custom.txt
@@ -71,6 +71,7 @@ prereleases
 recurse
 recursing
 regex
+reparsing
 sharepoint
 sharepoints
 sortable
@@ -87,8 +88,10 @@ syntaxes
 tuple
 un
 unclosed
+unfound
 unintuitive
 unordered
+untrusted
 versa
 wildcard
 zsh

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -1,8 +1,17 @@
 # Changelog
 
-## 10.2.2
+## 11.0
 
+-   **NEW**: Reduce/combine nested `EXTGLOB`/`EXTMATCH` regular expression patterns when possible to reduce deeply
+    nested patterns.
 -   **NEW**: Added ZSH style numerical ranges (`<0-9>`) via new `NUMRANGE` flag.
+-   **BREAK**: Previously, translation would have a capture group for every extended glob pattern when
+    `EXTGLOB`/`EXTMATCH` was enabled. Due to the new feature added that reduces extended glob group nesting, groups no
+    longer appear exactly as specified. Moving forward, capturing groups are not included by default. If you need the
+    old behavior, it can be enabled in a `translate()` call via the `CAPTURE` flag. This flag will cause extended glob
+    reduction to be turned off and for capturing groups to be enabled.
+-   **FIX**: Avoid reparsing sequences that have already been deemed not valid.
+-   **FIX**: Halt `EXTGLOB`/`EXTMATCH` parsing once an unclosed extended glob pattern is encountered.
 -   **FIX**: Fix case where an empty string would not match a pattern targeting an empty string.
 -   **FIX**: Ensure that consecutive stars are collapsed into a single regular expression pattern.
 -   **FIX**: Fix parsing `SPLIT` not accounting for POSIX character class.

--- a/docs/src/markdown/fnmatch.md
+++ b/docs/src/markdown/fnmatch.md
@@ -93,7 +93,7 @@ When applying multiple patterns, a file matches if it matches any of the pattern
 
 ```pycon
 >>> from wcmatch import fnmatch
->>> fnmatch.fnmatch('test.txt', ['*.txt', '*.py'], flags=fnmatch.EXTMATCH)
+>>> fnmatch.fnmatch('test.txt', ['*.txt', '*.py'])
 True
 ```
 
@@ -150,7 +150,7 @@ True
 def filter(filenames, patterns, *, flags=0, limit=1000, exclude=None):
 ```
 
-`filter` takes a list of filenames, a pattern (or list of patterns), and flags. It also allows configuring the [max 
+`filter` takes a list of filenames, a pattern (or list of patterns), and flags. It also allows configuring the [max
 pattern limit](#multi-pattern-limits). Exclusion patterns can be specified via the `exclude` parameter which takes a
 pattern or a list of patterns.It returns a list of all files that matched the pattern(s). The same logic used for
 [`fnmatch`](#fnmatch) is used for `filter`, albeit more efficient for processing multiple files.
@@ -241,21 +241,24 @@ matches at least one inclusion pattern and matches **none** of the exclusion pat
 ```
 
 The main goal of `translate` is to return a regex that matches a file path. Advanced regex features, such as extracting
-specific groups, are not really the goal, but, when using [`EXTMATCH`](#extmatch) patterns, extend groups will be
-returned as a capturing group pattern and can be utilized if that is found to be helpful. Advanced regex features such
-as naming groups does not currently fit into the pattern matching syntax is not currently planned.
-
-While in regex, patterns like `#!py r'(a)+'` would capture only the last character, even though multiple where matched,
-we wrap the entire group to be captured: `#!py '+(a)'` --> `#!py r'((a)+)'`.
+specific groups, are not really the goal. When using [`EXTMATCH`](#extmatch) patterns, extend groups will be
+returned as a capturing groups, but only when the [`CAPTURE`](#capture) flag is enabled. [`CAPTURE`](#capture) only
+works with `translate` and will also disable regex pattern optimizations to ensure the regex groups align with the user
+input groups. Advanced regex features such as naming groups does not currently fit into the pattern matching syntax is
+not currently planned.
 
 ```pycon
 >>> from wcmatch import fnmatch
 >>> import re
->>> gpat = fnmatch.translate("@(file)+([[:digit:]])@(.*)", flags=fnmatch.EXTMATCH)
+>>> gpat = fnmatch.translate("@(file)+([[:digit:]])@(.*)", flags=fnmatch.EXTMATCH | fnmatch.CAPTURE)
 >>> pat = re.compile(gpat[0][0])
 >>> pat.match('file33.test.txt').groups()
 ('file', '33', '.test.txt')
 ```
+
+> [!note] Behavior Change in 11.0
+> Capturing groups used to be created for each extended group by default, but now requires the [`CAPTURE`](#capture)
+> flag.
 
 > [!new] New 6.0
 > `limit` was added in 6.0.
@@ -400,6 +403,19 @@ etc. See the [syntax overview](#syntax) for more information.
 > When using `EXTMATCH` and [`NEGATE`](#negate) together, if a pattern starts with `!(`, the pattern will not
 > be treated as a [`NEGATE`](#negate) pattern (even if `!(` doesn't yield a valid `EXTMATCH` pattern). To
 > negate a pattern that starts with a literal `(`, you must escape the bracket: `!\(`.
+
+#### `fnmatch.CAPTURE, glob.TC` {: #capture}
+
+> [!new] New 11.0
+> Added in 11.0 and only applies when passed to [`translate()`](#translate).
+
+Wildcard Match employs some optimizations to produce less deeply nested regular expressions. The idea is simply that
+certain patterns are equivalent to more deeply nested patterns: e.g. `+(a|@(b|c)|d)` -> `+(a|b|c|d)`, `+(a|*(b|c))` ->
+`+(a|b|c|)`, or `!(!(a|b))` -> `@(a|b)`.
+
+The [`translate()`](#translate) function will return the regular expression with capturing groups for each extended glob
+group, when [`EXTMATCH`](#extglob) and `CAPTURE`. This has the side effect of disabling some regex optimizations related
+to extended glob patterns, but this is to ensure that the input groups match the output groups.
 
 #### `fnmatch.BRACE, fnmatch.B` {: #brace}
 

--- a/docs/src/markdown/glob.md
+++ b/docs/src/markdown/glob.md
@@ -511,11 +511,11 @@ True
 #### `glob.globfilter` {: #globfilter}
 
 ```py
-def globfilter(filenames, patterns, *, flags=0, root_dir=None, dir_fd=None, limit=1000, method=None):
+def globfilter(filenames, patterns, *, flags=0, root_dir=None, dir_fd=None, limit=1000, exclude=None):
 ```
 
 `globfilter` takes a list of file paths (strings or path-like objects), a pattern (or list of patterns), flags, and an
-optional root directory and/or directory file descriptor. It also allows configuring the 
+optional root directory and/or directory file descriptor. It also allows configuring the
 [max pattern limit](#multi-pattern-limits). Exclusion patterns can be specified via the `exclude` parameter which takes
 a pattern or a list of patterns.It returns a list of all files paths that matched the pattern(s). The same logic used
 for [`globmatch`](#globmatch) is used for `globfilter`, albeit more efficient for processing multiple files.
@@ -568,21 +568,24 @@ matches at least one inclusion pattern and matches **none** of the exclusion pat
 ```
 
 The main goal of `translate` is to return a regex that matches a file path. Advanced regex features, such as extracting
-specific groups, are not really the goal, but, when using [`EXTGLOB`](#extglob) patterns, extend groups will be
-returned as a capturing group pattern and can be utilized if that is found to be helpful. Advanced regex features such
-as naming groups does not currently fit into the pattern matching syntax is not currently planned.
-
-While in regex, patterns like `#!py r'(a)+'` would capture only the last character, even though multiple where matched,
-we wrap the entire group to be captured: `#!py '+(a)'` --> `#!py r'((a)+)'`.
+specific groups, are not really the goal. When using [`EXTGLOB`](#extglob) patterns, extend groups will be
+returned as a capturing groups, but only when the [`CAPTURE`](#capture) flag is enabled. [`CAPTURE`](#capture) only
+works with `translate` and will also disable regex pattern optimizations to ensure the regex groups align with the user
+input groups. Advanced regex features such as naming groups does not currently fit into the pattern matching syntax is
+not currently planned.
 
 ```pycon
 >>> from wcmatch import glob
 >>> import re
->>> gpat = glob.translate("@(file)+([[:digit:]])@(.*)", flags=glob.EXTGLOB)
+>>> gpat = glob.translate("@(file)+([[:digit:]])@(.*)", flags=glob.EXTGLOB | glob.CAPTURE)
 >>> pat = re.compile(gpat[0][0])
 >>> pat.match('file33.test.txt').groups()
 ('file', '33', '.test.txt')
 ```
+
+> [!note] Behavior Change in 11.0
+> Capturing groups used to be created for each extended group by default, but now requires the [`CAPTURE`](#capture)
+> flag.
 
 > [!new] New 6.0
 > `limit` was added in 6.0.
@@ -603,8 +606,8 @@ def compile(patterns, *, flags=0, limit=1000, exclude=None):
 
 The `compile` function takes a file pattern (or list of patterns) and flags. It also allows configuring the [max pattern
 limit](#multi-pattern-limits). Exclusion patterns can be specified via the `exclude` parameter which takes a pattern or
-a list of patterns. It returns a [`WcMatcher`](#wcmatcher) object which can match or filter file paths depending on
-which method is called. 
+a list of patterns. It returns a[`WcMatcher`](#wcmatcher) object which can match or filter file paths depending on which
+method is called.
 
 ```pycon
 >>> import wcmatch.glob as glob
@@ -963,6 +966,19 @@ often the name used in Bash.
 > When using `EXTGLOB` and [`NEGATE`](#negate) together, if a pattern starts with `!(`, the pattern will not
 > be treated as a [`NEGATE`](#negate) pattern (even if `!(` doesn't yield a valid `EXTGLOB` pattern). To negate
 > a pattern that starts with a literal `(`, you must escape the bracket: `!\(`.
+
+#### `fnmatch.CAPTURE, glob.TC` {: #capture}
+
+> [!new] New 11.0
+> Added in 11.0 and only applies when passed to [`translate()`](#translate).
+
+Wildcard Match employs some optimizations to produce less deeply nested regular expressions. The idea is simply that
+certain patterns are equivalent to more deeply nested patterns: e.g. `+(a|@(b|c)|d)` -> `+(a|b|c|d)`, `+(a|*(b|c))` ->
+`+(a|b|c|)`, or `!(!(a|b))` -> `@(a|b)`.
+
+The [`translate()`](#translate) function will return the regular expression with capturing groups for each extended glob
+group, when [`EXTGLOB`/`EXTMATCH`](#extglob) and `CAPTURE`. This has the side effect of disabling some regex
+optimizations related to extended glob patterns, but this is to ensure that the input groups match the output groups.
 
 #### `glob.BRACE, glob.B` {: #brace}
 

--- a/docs/src/markdown/pathlib.md
+++ b/docs/src/markdown/pathlib.md
@@ -247,8 +247,7 @@ def match(self, patterns, *, flags=0, limit=1000, exclude=None):
 
 `match` takes a pattern (or list of patterns), and flags.  It also allows configuring the [max pattern
 limit](#multi-pattern-limits). Exclusion patterns can be specified via the `exclude` parameter which takes a pattern or
-a list of patterns. It will return a boolean indicating whether the object's file path was matched by the
-pattern(s).
+a list of patterns. It will return a boolean indicating whether the object's file path was matched by the pattern(s).
 
 `match` mimics Python's `pathlib` version of `match`. Python's `match` uses a right to left evaluation that behaves
 like [`rglob`](#rglob) but as a matcher instead of a globbing function. Wildcard Match emulates this behavior as well.
@@ -329,10 +328,10 @@ def glob(self, patterns, *, flags=0, limit=1000, exclude=None):
 ```
 
 `glob` takes a pattern (or list of patterns) and flags. It also allows configuring the [max pattern
-limit](#multi-pattern-limits). It will crawl the file system, relative to the current [`Path`](#path) object,
-returning a generator of [`Path`](#path) objects. If a file/folder matches any regular, inclusion pattern, it is
-considered a match.  If a file matches *any* exclusion pattern (specified via `exclude` or using negation patterns when
-enabling the [`NEGATE`](#negate) flag), then it will not be returned.
+limit](#multi-pattern-limits). It will crawl the file system, relative to the current [`Path`](#path) object, returning
+a generator of [`Path`](#path) objects. If a file/folder matches any regular, inclusion pattern, it is considered a
+match.  If a file matches *any* exclusion pattern (specified via `exclude` or using negation patterns when enabling the
+[`NEGATE`](#negate) flag), then it will not be returned.
 
 This method calls our own [`iglob`](./glob.md#iglob) implementation, and as such, should behave in the same manner
 in respect to features, the one exception being that instead of returning path strings in the generator, it will return
@@ -362,10 +361,10 @@ def rglob(self, patterns, *, flags=0, path_limit=1000, exclude=None):
 ```
 
 `rglob` takes a pattern (or list of patterns) and flags. It also allows configuring the [max pattern
-limit](#multi-pattern-limits). It will crawl the file system, relative to the current [`Path`](#path) object,
-returning a generator of [`Path`](#path) objects. If a file/folder matches any regular patterns, it is considered
-a match.  If a file matches *any* exclusion pattern (specified via `exclude` or using negation patterns when enabling
-the [`NEGATE`](#negate) flag), then it will be not be returned.
+limit](#multi-pattern-limits). It will crawl the file system, relative to the current [`Path`](#path) object, returning
+a generator of [`Path`](#path) objects. If a file/folder matches any regular patterns, it is considered a match.  If a
+file matches *any* exclusion pattern (specified via `exclude` or using negation patterns when enabling the
+[`NEGATE`](#negate) flag), then it will be not be returned.
 
 `rglob` mimics Python's [`pathlib`][pathlib] version of `rglob` in that it uses a recursive logic. What this means is
 that when you are matching a path in the form `some/path/name`, the patterns `name`, `path/name` and `some/path/name`

--- a/docs/src/markdown/wcmatch.md
+++ b/docs/src/markdown/wcmatch.md
@@ -32,10 +32,10 @@ is matched, skipped, or when there is an error. There are also hooks where you c
 Parameter         | Default       | Description
 ----------------- | ------------- | -----------
 `root_dir`        |               | The root directory to search.
-`file_pattern`    | `#!py ''`    | One or more patterns separated by `|`. You can define exceptions by starting a pattern with `!` (or `-` if [`MINUSNEGATE`](#minusnegate) is set). The default is an empty string, but if an empty string is used, all files will be matched.
-`exclude_pattern` | `#!py ''`    | Zero or more folder exclude patterns separated by `|`. You can define exceptions by starting a pattern with `!` (or `-` if [`MINUSNEGATE`](#minusnegate) is set).
-`flags`           | `#!py 0`     | Flags to alter behavior of folder and file matching. See [Flags](#flags) for more info.
-`limit`           | `#!py 1000`  | Allows configuring the [max pattern limit](#multi-pattern-limits).
+`file_pattern`    | `#!py ''`     | One or more patterns separated by `|`. You can define exceptions by starting a pattern with `!` (or `-` if [`MINUSNEGATE`](#minusnegate) is set). The default is an empty string, but if an empty string is used, all files will be matched.
+`exclude_pattern` | `#!py ''`     | Zero or more folder exclude patterns separated by `|`. You can define exceptions by starting a pattern with `!` (or `-` if [`MINUSNEGATE`](#minusnegate) is set).
+`flags`           | `#!py 0`      | Flags to alter behavior of folder and file matching. See [Flags](#flags) for more info.
+`limit`           | `#!py 1000`   | Allows configuring the [max pattern limit](#multi-pattern-limits).
 
 > [!note]
 > Dots are not treated special in `wcmatch`. When the `HIDDEN` flag is not included, all hidden files (system and dot

--- a/tests/test_fnmatch.py
+++ b/tests/test_fnmatch.py
@@ -153,6 +153,11 @@ class TestFnMatch:
         ['!(2)_@(foo|bar)', '1_foo', True, fnmatch.E],
         ['!(!(2|3))_@(foo|bar)', '2_foo', True, fnmatch.E],
 
+        # Nested extended list reduction cases
+        ['!(!(2|3))_@(foo|bar)', '2_foo', True, fnmatch.E],
+        ['@(!(2))_!(!(foo|bar))', '1_foo', True, fnmatch.E],
+        ['@(!(2))_!(!(foo|bar)_test)', '1_foo_test', True, fnmatch.E],
+
         # POSIX style character classes
         ['[[:alnum:]]bc', 'zbc', True, 0],
         ['[[:alnum:]]bc', '1bc', True, 0],
@@ -350,7 +355,7 @@ class TestFnMatchTranslate(unittest.TestCase):
     def test_capture_groups(self):
         """Test capture groups."""
 
-        gpat = fnmatch.translate("test @(this) +(many) ?(meh)*(!) !(not this)@(.md)", flags=fnmatch.E)
+        gpat = fnmatch.translate("test @(this) +(many) ?(meh)*(!) !(not this)@(.md)", flags=fnmatch.E | fnmatch.TC)
         pat = re.compile(gpat[0][0])
         match = pat.match('test this manymanymany meh!!!!! okay.md')
         self.assertEqual(('this', 'manymanymany', 'meh', '!!!!!', 'okay', '.md'), match.groups())
@@ -358,7 +363,7 @@ class TestFnMatchTranslate(unittest.TestCase):
     def test_nested_capture_groups(self):
         """Test nested capture groups."""
 
-        gpat = fnmatch.translate("@(file)@(+([[:digit:]]))@(.*)", flags=fnmatch.E)
+        gpat = fnmatch.translate("@(file)@(+([[:digit:]]))@(.*)", flags=fnmatch.E | fnmatch.TC)
         pat = re.compile(gpat[0][0])
         match = pat.match('file33.test.txt')
         self.assertEqual(('file', '33', '33', '.test.txt'), match.groups())
@@ -366,7 +371,7 @@ class TestFnMatchTranslate(unittest.TestCase):
     def test_list_groups(self):
         """Test capture groups with lists."""
 
-        gpat = fnmatch.translate("+(f|i|l|e)+([[:digit:]])@(.*)", flags=fnmatch.E)
+        gpat = fnmatch.translate("+(f|i|l|e)+([[:digit:]])@(.*)", flags=fnmatch.E | fnmatch.TC)
         pat = re.compile(gpat[0][0])
         match = pat.match('file33.test.txt')
         self.assertEqual(('file', '33', '.test.txt'), match.groups())
@@ -903,6 +908,166 @@ class TestExpansionLimit(unittest.TestCase):
 
         with self.assertRaises(_wcparse.PatternLimitException):
             fnmatch.translate('{1..11}', flags=fnmatch.BRACE, limit=10)
+
+
+class TestExtendedCases(unittest.TestCase):
+    """Test extended match cases."""
+
+    def assert_group_equal(self, pat1, pat2):
+        """Compare equivalent groups."""
+
+        regex1 = fnmatch.translate(pat1, flags=fnmatch.E)[0][0]
+        regex2 = fnmatch.translate(pat2, flags=fnmatch.E)[0][0]
+        try:
+            self.assertEqual(regex1, regex2)
+        except Exception:
+            print(f"{pat1} <=> {pat2}")
+            raise
+
+    def test_and(self):
+        """Test reduction of the `@` group and other groups."""
+
+        self.assert_group_equal('@(@(a|b)|c|d)', '@(a|b|c|d)')
+        self.assert_group_equal('@(a|@(b|c)|d)', '@(a|b|c|d)')
+        self.assert_group_equal('@(a|b|@(c|d))', '@(a|b|c|d)')
+
+        self.assert_group_equal('?(@(a|b)|c|d)', '?(a|b|c|d)')
+        self.assert_group_equal('?(a|@(b|c)|d)', '?(a|b|c|d)')
+        self.assert_group_equal('?(a|b|@(c|d))', '?(a|b|c|d)')
+
+        self.assert_group_equal('*(@(a|b)|c|d)', '*(a|b|c|d)')
+        self.assert_group_equal('*(a|@(b|c)|d)', '*(a|b|c|d)')
+        self.assert_group_equal('*(a|b|@(c|d))', '*(a|b|c|d)')
+
+        self.assert_group_equal('+(@(a|b)|c|d)', '+(a|b|c|d)')
+        self.assert_group_equal('+(a|@(b|c)|d)', '+(a|b|c|d)')
+        self.assert_group_equal('+(a|b|@(c|d))', '+(a|b|c|d)')
+
+        self.assert_group_equal('!(@(a|b)|c|d)', '!(a|b|c|d)')
+        self.assert_group_equal('!(a|@(b|c)|d)', '!(a|b|c|d)')
+        self.assert_group_equal('!(a|b|@(c|d))', '!(a|b|c|d)')
+
+        self.assert_group_equal('@(@(a|b|c))', '@(a|b|c)')
+        self.assert_group_equal('?(@(a|b|c))', '?(a|b|c)')
+        self.assert_group_equal('*(@(a|b|c))', '*(a|b|c)')
+        self.assert_group_equal('+(@(a|b|c))', '+(a|b|c)')
+        self.assert_group_equal('!(@(a|b|c))', '!(a|b|c)')
+
+    def test_one_or_none(self):
+        """Test reduction of the `?` group and other groups."""
+
+        self.assert_group_equal('@(?(a|b)|c|d)', '@(a|b||c|d)')
+        self.assert_group_equal('@(a|?(b|c)|d)', '@(a|b|c||d)')
+        self.assert_group_equal('@(a|b|?(c|d))', '@(a|b|c|d|)')
+
+        self.assert_group_equal('?(?(a|b)|c|d)', '?(a|b|c|d)')
+        self.assert_group_equal('?(a|?(b|c)|d)', '?(a|b|c|d)')
+        self.assert_group_equal('?(a|b|?(c|d))', '?(a|b|c|d)')
+
+        self.assert_group_equal('*(?(a|b)|c|d)', '*(a|b|c|d)')
+        self.assert_group_equal('*(a|?(b|c)|d)', '*(a|b|c|d)')
+        self.assert_group_equal('*(a|b|?(c|d))', '*(a|b|c|d)')
+
+        self.assert_group_equal('+(?(a|b)|c|d)', '+(a|b||c|d)')
+        self.assert_group_equal('+(a|?(b|c)|d)', '+(a|b|c||d)')
+        self.assert_group_equal('+(a|b|?(c|d))', '+(a|b|c|d|)')
+
+        self.assert_group_equal('!(?(a|b)|c|d)', '!(a|b||c|d)')
+        self.assert_group_equal('!(a|?(b|c)|d)', '!(a|b|c||d)')
+        self.assert_group_equal('!(a|b|?(c|d))', '!(a|b|c|d|)')
+
+        self.assert_group_equal('@(?(a|b|c))', '?(a|b|c)')
+        self.assert_group_equal('?(?(a|b|c))', '?(a|b|c)')
+        self.assert_group_equal('*(?(a|b|c))', '*(a|b|c)')
+        self.assert_group_equal('+(?(a|b|c))', '*(a|b|c)')
+
+    def test_more_or_none(self):
+        """Test reduction of the `*` group and other groups."""
+
+        self.assert_group_equal('*(*(a|b)|c|d)', '*(a|b|c|d)')
+        self.assert_group_equal('*(a|*(b|c)|d)', '*(a|b|c|d)')
+        self.assert_group_equal('*(a|b|*(c|d))', '*(a|b|c|d)')
+
+        self.assert_group_equal('+(*(a|b)|c|d)', '+(a|b||c|d)')
+        self.assert_group_equal('+(a|*(b|c)|d)', '+(a|b|c||d)')
+        self.assert_group_equal('+(a|b|*(c|d))', '+(a|b|c|d|)')
+
+        self.assert_group_equal('@(*(a|b|c))', '*(a|b|c)')
+
+    def test_one_or_more(self):
+        """Test reduction of the `+` group and other groups."""
+
+        self.assert_group_equal('*(+(a|b)|c|d)', '*(a|b|c|d)')
+        self.assert_group_equal('*(a|+(b|c)|d)', '*(a|b|c|d)')
+        self.assert_group_equal('*(a|b|+(c|d))', '*(a|b|c|d)')
+
+        self.assert_group_equal('+(+(a|b)|c|d)', '+(a|b|c|d)')
+        self.assert_group_equal('+(a|+(b|c)|d)', '+(a|b|c|d)')
+        self.assert_group_equal('+(a|b|+(c|d))', '+(a|b|c|d)')
+
+        self.assert_group_equal('@(+(a|b|c))', '+(a|b|c)')
+        self.assert_group_equal('?(+(a|b|c))', '*(a|b|c)')
+        self.assert_group_equal('*(+(a|b|c))', '*(a|b|c)')
+
+    def test_not(self):
+        """Test reduction of the `!` group and other groups."""
+
+        self.assert_group_equal('@(!(a|b|c))', '!(a|b|c)')
+        self.assert_group_equal('!(!(a|b|c))', '@(a|b|c)')
+
+    def test_mixed(self):
+        """Test mixed cases."""
+
+        self.assert_group_equal(
+            '!(!(@(@(a|b)|?(@(c|d)|?(e|f))|*(@(f|h)|?(i|j)|*(k|l)|+(m|n)))))',
+            '@(a|b|c|d|e|f||*(f|h|i|j|k|l|m|n))'
+        )
+
+    def test_empty_slots(self):
+        """Test empty slot reduction."""
+
+        self.assert_group_equal('+(||?(a|b)|c|d)', '+(|a|b|c|d)')
+        self.assert_group_equal('+(a|b|?(c|d)|||e)', '+(a|b|c|d||e)')
+        self.assert_group_equal('+(a|b||||?(c|d)|e)', '+(a|b||c|d|e)')
+        self.assert_group_equal('+(a|b|?(c|d)|||)', '+(a|b|c|d|)')
+
+        self.assert_group_equal('@(||||)', '@(|)')
+        self.assert_group_equal('@(|||a|b)', '@(|a|b)')
+        self.assert_group_equal('@(a|b|||)', '@(a|b|)')
+        self.assert_group_equal('@(a||||b)', '@(a||b)')
+
+    def test_parse_halt_split(self):
+        """Test halting of parsing."""
+
+        # Top level
+        p1 = '@(test+(a|b)'
+        p2 = R'@\(test+\(a|b\)'
+        self.assert_group_equal(p1, p2)
+
+        self.assertEqual(
+            len(fnmatch.translate(p1, flags=fnmatch.E | fnmatch.S)[0]),
+            len(fnmatch.translate(p2, flags=fnmatch.E | fnmatch.S)[0])
+        )
+
+        # Nested
+        p1 = '@(@(test+(a|b)'
+        p2 = R'@\(@\(test+\(a|b\)'
+        self.assert_group_equal(p1, p2)
+
+        self.assertEqual(
+            len(fnmatch.translate(p1, flags=fnmatch.E | fnmatch.S)[0]),
+            len(fnmatch.translate(p2, flags=fnmatch.E | fnmatch.S)[0])
+        )
+
+        # Deeply nested
+        p1 = '@(@(@(test+(a|b)'
+        p2 = R'@\(@\(@\(test+\(a|b\)'
+        self.assert_group_equal(p1, p2)
+
+        self.assertEqual(
+            len(fnmatch.translate(p1, flags=fnmatch.E | fnmatch.S)[0]),
+            len(fnmatch.translate(p2, flags=fnmatch.E | fnmatch.S)[0])
+        )
 
 
 class TestTypes(unittest.TestCase):

--- a/tests/test_globmatch.py
+++ b/tests/test_globmatch.py
@@ -1123,7 +1123,7 @@ class TestGlobMatchSpecial(unittest.TestCase):
     def test_capture_groups(self):
         """Test capture groups."""
 
-        gpat = glob.translate("test/@(this)/+(many)/?(meh)*(!)/!(not this)@(.md)", flags=glob.E)
+        gpat = glob.translate("test/@(this)/+(many)/?(meh)*(!)/!(not this)@(.md)", flags=glob.E | glob.TC)
         pat = re.compile(gpat[0][0])
         match = pat.match(os.path.normpath('test/this/manymanymany/meh!!!!!/okay.md'))
         self.assertEqual(('this', 'manymanymany', 'meh', '!!!!!', 'okay', '.md'), match.groups())
@@ -1131,7 +1131,7 @@ class TestGlobMatchSpecial(unittest.TestCase):
     def test_nested_capture_groups(self):
         """Test nested capture groups."""
 
-        gpat = glob.translate("@(file)@(+([[:digit:]]))@(.*)", flags=glob.E)
+        gpat = glob.translate("@(file)@(+([[:digit:]]))@(.*)", flags=glob.E | glob.TC | glob.TC)
         pat = re.compile(gpat[0][0])
         match = pat.match('file33.test.txt')
         self.assertEqual(('file', '33', '33', '.test.txt'), match.groups())
@@ -1139,7 +1139,7 @@ class TestGlobMatchSpecial(unittest.TestCase):
     def test_list_groups(self):
         """Test capture groups with lists."""
 
-        gpat = glob.translate("+(f|i|l|e)+([[:digit:]])@(.*)", flags=glob.E)
+        gpat = glob.translate("+(f|i|l|e)+([[:digit:]])@(.*)", flags=glob.E | glob.TC)
         pat = re.compile(gpat[0][0])
         match = pat.match('file33.test.txt')
         self.assertEqual(('file', '33', '.test.txt'), match.groups())
@@ -1277,6 +1277,11 @@ class TestGlobMatchSpecial(unittest.TestCase):
                     ) for x in glob.glob(b'!**/*.md', flags=self.flags | glob.SPLIT)
             )
         )
+
+    def test_incomplte_sequence_in_incomplete_extended_group(self):
+        """Test that within an incomplete extended group, a complete sequence followed by incomplete sequence works."""
+
+        self.assertTrue(glob.globmatch('@(a[def', '@([abc][def', flags=glob.E))
 
     def test_glob_integrity(self):
         """`globmatch` must match what glob globs."""
@@ -1712,8 +1717,10 @@ class TestIsMagic(unittest.TestCase):
         self.assertTrue(glob.is_magic("test]"))
         self.assertTrue(glob.is_magic("test?"))
         self.assertTrue(glob.is_magic("test\\"))
+        self.assertFalse(glob.is_magic("test<"))
+        self.assertFalse(glob.is_magic("test>"))
 
-        self.assertFalse(glob.is_magic("test~!()-/|{}"))
+        self.assertFalse(glob.is_magic("test~!()-/|<>{}"))
 
     def test_extmatch(self):
         """Test extended match magic."""
@@ -1726,7 +1733,7 @@ class TestIsMagic(unittest.TestCase):
         self.assertTrue(glob.is_magic("test(", flags=glob.EXTGLOB))
         self.assertTrue(glob.is_magic("test)", flags=glob.EXTGLOB))
 
-        self.assertFalse(glob.is_magic("test~!-/|{}", flags=glob.EXTGLOB))
+        self.assertFalse(glob.is_magic("test~!-/|{}<>", flags=glob.EXTGLOB))
 
     def test_negate(self):
         """Test negate magic."""
@@ -1738,7 +1745,7 @@ class TestIsMagic(unittest.TestCase):
         self.assertTrue(glob.is_magic("test\\", flags=glob.NEGATE))
         self.assertTrue(glob.is_magic("test!", flags=glob.NEGATE))
 
-        self.assertFalse(glob.is_magic("test~()-/|{}", flags=glob.NEGATE))
+        self.assertFalse(glob.is_magic("test~()-/|{}<>", flags=glob.NEGATE))
 
     def test_minusnegate(self):
         """Test minus negate magic."""
@@ -1750,7 +1757,7 @@ class TestIsMagic(unittest.TestCase):
         self.assertTrue(glob.is_magic("test\\", flags=glob.NEGATE | glob.MINUSNEGATE))
         self.assertTrue(glob.is_magic("test-", flags=glob.NEGATE | glob.MINUSNEGATE))
 
-        self.assertFalse(glob.is_magic("test~()!/|{}", flags=glob.NEGATE | glob.MINUSNEGATE))
+        self.assertFalse(glob.is_magic("test~()!/|{}<>", flags=glob.NEGATE | glob.MINUSNEGATE))
 
     def test_brace(self):
         """Test brace magic."""
@@ -1763,7 +1770,7 @@ class TestIsMagic(unittest.TestCase):
         self.assertTrue(glob.is_magic("test{", flags=glob.BRACE))
         self.assertTrue(glob.is_magic("test}", flags=glob.BRACE))
 
-        self.assertFalse(glob.is_magic("test~!-/|", flags=glob.BRACE))
+        self.assertFalse(glob.is_magic("test~!-/|<>", flags=glob.BRACE))
 
     def test_split(self):
         """Test split magic."""
@@ -1775,7 +1782,7 @@ class TestIsMagic(unittest.TestCase):
         self.assertTrue(glob.is_magic("test\\", flags=glob.SPLIT))
         self.assertTrue(glob.is_magic("test|", flags=glob.SPLIT))
 
-        self.assertFalse(glob.is_magic("test~()-!/", flags=glob.SPLIT))
+        self.assertFalse(glob.is_magic("test~()-!/<>", flags=glob.SPLIT))
 
     def test_tilde(self):
         """Test tilde magic."""
@@ -1787,7 +1794,20 @@ class TestIsMagic(unittest.TestCase):
         self.assertTrue(glob.is_magic("test\\", flags=glob.GLOBTILDE))
         self.assertTrue(glob.is_magic("test~", flags=glob.GLOBTILDE))
 
-        self.assertFalse(glob.is_magic("test|()-!/", flags=glob.GLOBTILDE))
+        self.assertFalse(glob.is_magic("test|()-!/<>", flags=glob.GLOBTILDE))
+
+    def test_numrange(self):
+        """Test number range magic."""
+
+        self.assertTrue(glob.is_magic("test*", flags=glob.NUMRANGE))
+        self.assertTrue(glob.is_magic("test[", flags=glob.NUMRANGE))
+        self.assertTrue(glob.is_magic("test]", flags=glob.NUMRANGE))
+        self.assertTrue(glob.is_magic("test?", flags=glob.NUMRANGE))
+        self.assertTrue(glob.is_magic("test\\", flags=glob.NUMRANGE))
+        self.assertTrue(glob.is_magic("test<", flags=glob.NUMRANGE))
+        self.assertTrue(glob.is_magic("test>", flags=glob.NUMRANGE))
+
+        self.assertFalse(glob.is_magic("test~|()-!/{}", flags=glob.NUMRANGE))
 
     def test_all(self):
         """Test tilde magic."""
@@ -1797,7 +1817,8 @@ class TestIsMagic(unittest.TestCase):
             glob.NEGATE |
             glob.BRACE |
             glob.SPLIT |
-            glob.GLOBTILDE
+            glob.GLOBTILDE |
+            glob.NUMRANGE
         )
 
         self.assertTrue(glob.is_magic("test*", flags=flags))
@@ -1814,6 +1835,8 @@ class TestIsMagic(unittest.TestCase):
         self.assertTrue(glob.is_magic("test}", flags=flags))
         self.assertTrue(glob.is_magic("test~", flags=flags))
         self.assertTrue(glob.is_magic("test-", flags=flags | glob.MINUSNEGATE))
+        self.assertTrue(glob.is_magic("test<", flags=flags))
+        self.assertTrue(glob.is_magic("test>", flags=flags))
 
         self.assertFalse(glob.is_magic("test-", flags=flags))
         self.assertFalse(glob.is_magic("test!", flags=flags | glob.MINUSNEGATE))
@@ -1826,7 +1849,8 @@ class TestIsMagic(unittest.TestCase):
             glob.NEGATE |
             glob.BRACE |
             glob.SPLIT |
-            glob.GLOBTILDE
+            glob.GLOBTILDE |
+            glob.NUMRANGE
         )
 
         self.assertTrue(glob.is_magic(b"test*", flags=flags))
@@ -1843,6 +1867,8 @@ class TestIsMagic(unittest.TestCase):
         self.assertTrue(glob.is_magic(b"test}", flags=flags))
         self.assertTrue(glob.is_magic(b"test~", flags=flags))
         self.assertTrue(glob.is_magic(b"test-", flags=flags | glob.MINUSNEGATE))
+        self.assertTrue(glob.is_magic(b"test<", flags=glob.NUMRANGE))
+        self.assertTrue(glob.is_magic(b"test>", flags=glob.NUMRANGE))
 
         self.assertFalse(glob.is_magic(b"test-", flags=flags))
         self.assertFalse(glob.is_magic(b"test!", flags=flags | glob.MINUSNEGATE))
@@ -1854,15 +1880,16 @@ class TestIsMagic(unittest.TestCase):
             glob.EXTGLOB |
             glob.NEGATE |
             glob.FORCEWIN |
-            glob.GLOBTILDE
+            glob.GLOBTILDE |
+            glob.NUMRANGE
         )
 
-        self.assertFalse(glob.is_magic('//?/UNC/server/*[]!|(){}~-/', flags=flags))
-        self.assertFalse(glob.is_magic('//?/UNC/server/*[]!|()~-/', flags=flags | glob.BRACE))
-        self.assertFalse(glob.is_magic('//?/UNC/server/*[]!(){}~-/', flags=flags | glob.SPLIT))
+        self.assertFalse(glob.is_magic('//?/UNC/server/*[]!|(){}~-<>/', flags=flags))
+        self.assertFalse(glob.is_magic('//?/UNC/server/*[]!|()~-<>/', flags=flags | glob.BRACE))
+        self.assertFalse(glob.is_magic('//?/UNC/server/*[]!(){}~-<>/', flags=flags | glob.SPLIT))
 
-        self.assertTrue(glob.is_magic('//?/UNC/server/*[]!|(){}|~-/', flags=flags | glob.BRACE))
-        self.assertTrue(glob.is_magic('//?/UNC/server/*[]!(){}|~-/', flags=flags | glob.SPLIT))
+        self.assertTrue(glob.is_magic('//?/UNC/server/*[]!|(){}|~-<>/', flags=flags | glob.BRACE))
+        self.assertTrue(glob.is_magic('//?/UNC/server/*[]!(){}|~-<>/', flags=flags | glob.SPLIT))
         self.assertTrue(glob.is_magic(R'\\\\server\\mount\\', flags=flags))
 
 
@@ -1990,3 +2017,37 @@ class TestPrecompile(unittest.TestCase):
         m5 = copy.copy(m1)
         self.assertTrue(m1 == m5)
         self.assertTrue(m5 in {m1})
+
+
+@unittest.skipUnless(not sys.platform.startswith('win'), "Unix/Linux test")
+class TestPerformance(unittest.TestCase):
+    """Test performance."""
+
+    def test_performance(self):
+        """Test performance of of specific cases."""
+
+        import signal
+        import time
+
+        LIMIT = 5.0
+
+        class Timeout(Exception):
+            pass
+
+        signal.signal(signal.SIGALRM, lambda *_: (_ for _ in ()).throw(Timeout()))
+        signal.setitimer(signal.ITIMER_REAL, LIMIT)
+        t = time.perf_counter()
+        dt = None
+        try:
+            glob.compile("@(" * 900, flags=glob.E)
+            dt = time.perf_counter() - t
+        except Timeout:
+            pass
+        finally:
+            signal.setitimer(signal.ITIMER_REAL, 0)
+
+        hung = dt is None
+        print(
+            f"{'> %.0f s (HANG)' % LIMIT if hung else '%.3f s' % dt}"
+        )
+        self.assertTrue(not hung and dt < 1.0)

--- a/wcmatch/__meta__.py
+++ b/wcmatch/__meta__.py
@@ -193,5 +193,5 @@ def parse_version(ver: str) -> Version:
     return Version(major, minor, micro, release, pre, post, dev)
 
 
-__version_info__ = Version(10, 2, 1, "final")
+__version_info__ = Version(11, 0, 0, "final")
 __version__ = __version_info__._get_canonical()

--- a/wcmatch/_wcparse.py
+++ b/wcmatch/_wcparse.py
@@ -7,7 +7,7 @@ import os
 from . import util
 from . import posix
 from . _wcmatch import WcRegexp
-from typing import AnyStr, Iterable, Pattern, Generic, Sequence, overload, Iterator
+from typing import AnyStr, Iterable, Pattern, Generic, Sequence, Iterator
 
 PATTERN_LIMIT = 1000
 
@@ -125,8 +125,10 @@ TILDE_SYM = (
 
 RE_ANCHOR = re.compile(r'^/+')
 RE_WIN_ANCHOR = re.compile(r'^(?:\\\\|/)+')
-RE_POSIX = re.compile(r':(alnum|alpha|ascii|blank|cntrl|digit|graph|lower|print|punct|space|upper|word|xdigit):\]')
+RE_POSIX = re.compile(r'\[:(alnum|alpha|ascii|blank|cntrl|digit|graph|lower|print|punct|space|upper|word|xdigit):\]')
 RE_NUM_RANGE = re.compile(r'([0-9]*-[0-9]*)>')
+RE_EMPTY_EXT_SLOTS = re.compile(r'[|]+')
+RE_EXT_GROUP = re.compile(r'[@*+?!]\(')
 
 SET_OPERATORS = frozenset(('&', '~', '|'))
 NEGATIVE_SYM = frozenset((b'!', '!'))
@@ -159,7 +161,8 @@ GLOBTILDE = 0x40000
 NOUNIQUE = 0x80000
 NODOTDIR = 0x100000
 GLOBSTARLONG = 0x200000
-NUMRANGE = 0x800000
+NUMRANGE = 0x400000
+CAPTURE = 0x800000
 
 # Internal flag
 _TRANSLATE = 0x100000000  # Lets us know we are performing a translation, and we just want the regex.
@@ -192,6 +195,7 @@ FLAG_MASK = (
     NOUNIQUE |
     NODOTDIR |
     NUMRANGE |
+    CAPTURE |
     _TRANSLATE |
     _ANCHOR |
     _EXTMATCHBASE |
@@ -274,6 +278,36 @@ _NO_WIN_DIR = (
     rb'^(?:.*?(?:[\\/]\.{1,2}[\\/]*|[\\/])|\.{1,2}[\\/]*)$'
 )
 
+# Mapping describing if an extended group can be appended to the parent group,
+# e.g. `@(a|@(b|c))` -> `@(a|b|c)`.
+# Some groups cannot be appended to the parent without an empty group.
+# e.g. `+(a|*(b|c))` -> `+(a|b|c|)`.
+# `{child: **}`
+EXT_REDUCE = {
+    '@': {'parent': {'@', '?', '*', '+', '!'}, 'empty': set()},
+    '?': {'parent': {'@', '?', '*', '+', '!'}, 'empty': {'@', '+', '!'}},
+    '*': {'parent': {'*', '+'}, 'empty': {'+',}},
+    '+': {'parent': {'*', '+'}, 'empty': set()},
+    '!': {'parent': set(), 'empty': set()}
+}  # type: dict[str, dict[str, set[str]]]
+
+# Mapping describing group promotion.
+# If the only child of a group is another group, it is possible that the
+# parent can take on the identity of the child group.
+# e.g. `!(!(a|b))` -> `@(a|b)`.
+# `{parent: {child: new_parent}}`
+EXT_PROMOTE = {
+    '@': {'?': '?', '*': '*', '+': '+', '!': '!'},
+    '?': {'@': '?', '*': '*', '+': '*'},
+    '*': {'@': '*'},
+    '+': {'@': '+', '?': '*', '*': '*'},
+    '!': {'@': '!', '!': '@'}
+}
+
+
+class ExtPromote(str):
+    """Promote extended group object."""
+
 
 class InvPlaceholder(str):
     """Placeholder for inverse pattern !(...)."""
@@ -289,16 +323,6 @@ class DotException(Exception):
 
 class PatternLimitException(Exception):
     """Pattern limit exception."""
-
-
-@overload
-def iter_patterns(patterns: str | Sequence[str]) -> Iterable[str]:
-    ...
-
-
-@overload
-def iter_patterns(patterns: bytes | Sequence[bytes]) -> Iterable[bytes]:
-    ...
 
 
 def iter_patterns(patterns: AnyStr | Sequence[AnyStr]) -> Iterable[AnyStr]:
@@ -596,26 +620,6 @@ def no_negate_flags(flags: int) -> int:
     return flags
 
 
-@overload
-def translate(
-    patterns: str | Sequence[str],
-    flags: int,
-    limit: int = PATTERN_LIMIT,
-    exclude: str | Sequence[str] | None = None
-) -> tuple[list[str], list[str]]:
-    ...
-
-
-@overload
-def translate(
-    patterns: bytes | Sequence[bytes],
-    flags: int,
-    limit: int = PATTERN_LIMIT,
-    exclude: bytes | Sequence[bytes] | None = None
-) -> tuple[list[bytes], list[bytes]]:
-    ...
-
-
 def translate(
     patterns: AnyStr | Sequence[AnyStr],
     flags: int,
@@ -629,7 +633,11 @@ def translate(
 
     if exclude is not None:
         flags = no_negate_flags(flags)
-        negative = translate(exclude, flags=flags | DOTMATCH | _NO_GLOBSTAR_CAPTURE, limit=limit)[0]
+        negative = translate(
+            exclude,
+            flags=flags | DOTMATCH | _NO_GLOBSTAR_CAPTURE,
+            limit=limit
+        )[0]
         limit -= len(negative)
 
     flags = (flags | _TRANSLATE) & FLAG_MASK
@@ -663,9 +671,7 @@ def translate(
     if negative and not positive:
         if flags & NEGATEALL:
             default = b'**' if isinstance(negative[0], bytes) else '**'
-            positive.append(
-                WcParse(default, flags | (GLOBSTAR if flags & PATHNAME else 0)).parse()
-            )
+            positive.append(WcParse(default, flags | (GLOBSTAR if flags & PATHNAME else 0)).parse())
 
     if positive and flags & NODIR:
         index = util.BYTES if isinstance(positive[0], bytes) else util.UNICODE
@@ -681,26 +687,6 @@ def split(pattern: AnyStr, flags: int) -> Iterable[AnyStr]:
         yield from WcSplit(pattern, flags).split()
     else:
         yield pattern
-
-
-@overload
-def compile_pattern(
-    patterns: str | Sequence[str],
-    flags: int,
-    limit: int = PATTERN_LIMIT,
-    exclude: str | Sequence[str] | None = None
-) -> tuple[list[Pattern[str]], list[Pattern[str]]]:
-    ...
-
-
-@overload
-def compile_pattern(
-    patterns: bytes | Sequence[bytes],
-    flags: int,
-    limit: int = PATTERN_LIMIT,
-    exclude: bytes | Sequence[bytes] | None = None
-) -> tuple[list[Pattern[bytes]], list[Pattern[bytes]]]:
-    ...
 
 
 def compile_pattern(
@@ -758,26 +744,6 @@ def compile_pattern(
     return positive, negative
 
 
-@overload
-def compile(  # noqa: A001
-    patterns: str | Sequence[str],
-    flags: int,
-    limit: int = PATTERN_LIMIT,
-    exclude: str | Sequence[str] | None = None
-) -> WcRegexp[str]:
-    ...
-
-
-@overload
-def compile(  # noqa: A001
-    patterns: bytes | Sequence[bytes],
-    flags: int,
-    limit: int = PATTERN_LIMIT,
-    exclude: bytes | Sequence[bytes] | None = None
-) -> WcRegexp[bytes]:
-    ...
-
-
 def compile(  # noqa: A001
     patterns: AnyStr | Sequence[AnyStr],
     flags: int,
@@ -811,6 +777,7 @@ class WcSplit(Generic[AnyStr]):
         self.extend = bool(flags & EXTMATCH)
         self.unix = is_unix_style(flags)
         self.bslash_abort = not self.unix
+        self.bad_sequence = -1
 
     def _sequence(self, i: util.StringIter) -> None:
         """Handle character group."""
@@ -856,36 +823,46 @@ class WcSplit(Generic[AnyStr]):
     def parse_extend(self, c: str, i: util.StringIter) -> bool:
         """Parse extended pattern lists."""
 
-        # Start list parsing
-        success = True
         index = i.index
-        list_type = c
+
+        if not i.match(RE_EXT_GROUP):
+            i.rewind(i.index - index)
+            return False
+
+        success = True
+        bad_sequence = self.bad_sequence
+
+        # Start list parsing
         try:
-            c = next(i)
-            if c != '(':
-                raise StopIteration
             while c != ')':
                 c = next(i)
 
-                if self.extend and c in EXT_TYPES and self.parse_extend(c, i):
-                    continue
+                if not self.extend:
+                    raise StopIteration
+
+                #See if we should parse a nested extended pattern.
+                if c in EXT_TYPES:
+                    if self.parse_extend(c, i):
+                        continue
 
                 if c == '\\':
                     try:
                         self._references(i)
                     except StopIteration:
                         pass
-                elif c == '[':
-                    index = i.index
+                elif c == '[' and (self.bad_sequence == -1 or i.index > self.bad_sequence):
+                    index2 = i.index
                     try:
                         self._sequence(i)
                     except StopIteration:
-                        i.rewind(i.index - index)
+                        self.bad_sequence = i.index
+                        i.rewind(i.index - index2)
 
         except StopIteration:
             success = False
-            c = list_type
             i.rewind(i.index - index)
+            self.bad_sequence = bad_sequence
+            self.extend = False
 
         return success
 
@@ -910,11 +887,12 @@ class WcSplit(Generic[AnyStr]):
                     self._references(i)
                 except StopIteration:
                     i.rewind(i.index - index)
-            elif c == '[':
+            elif c == '[' and (self.bad_sequence == -1 or i.index > self.bad_sequence):
                 index = i.index
                 try:
                     self._sequence(i)
                 except StopIteration:
+                    self.bad_sequence = i.index
                     i.rewind(i.index - index)
 
         if start < len(pattern):
@@ -956,13 +934,15 @@ class WcParse(Generic[AnyStr]):
         self.anchor = bool(flags & _ANCHOR)
         self.nodotdir = bool(flags & NODOTDIR)
         self.numrange = bool(flags & NUMRANGE)
-        self.capture = self.translate
+        self.capture = self.translate and bool(flags & CAPTURE)
         self.case_sensitive = get_case(flags)
         self.in_list = False
         self.inv_nest = False
         self.flags = flags
         self.inv_ext = 0
         self.unix = is_unix_style(self.flags)
+        self.bad_sequence = -1
+        self.ext_empty = False
         if not self.unix:
             self.win_drive_detect = self.pathname
             self.char_avoid = (ord('\\'), ord('/'), ord('.'))  # type: tuple[int, ...]
@@ -1215,7 +1195,7 @@ class WcParse(Generic[AnyStr]):
     def _handle_numrange(self, i: util.StringIter) -> str:
         """Handle ZSH style number range."""
 
-        m = i.match(RE_NUM_RANGE)
+        m = i.match_next(RE_NUM_RANGE)
         if m:
             start, end = [x.strip() for x in m.group(1).split('-')]
             return self.range_to_regex(int(start) if start else None, int(end) if end else None)
@@ -1528,7 +1508,7 @@ class WcParse(Generic[AnyStr]):
         Clean up current.
 
         Python doesn't have variable lookbehinds, so we have to do negative lookaheads.
-        !(...) when converted to regular expression is atomic, so once it matches, that's it.
+        `!(...)`, when converted to regular expression, is atomic, so once it matches, that's it.
         So we use the pattern `(?:(?!(?:stuff|to|exclude)<x>))[^/]*?)` where <x> is everything
         that comes after the negative group. `!(this|that)other` --> `(?:(?!(?:this|that)other))[^/]*?)`.
 
@@ -1554,39 +1534,55 @@ class WcParse(Generic[AnyStr]):
             index -= 1
         self.inv_ext = 0
 
-    def parse_extend(self, c: str, i: util.StringIter, current: list[str], reset_dot: bool = False) -> bool:
+    def parse_extend(
+        self,
+        c: str,
+        i: util.StringIter,
+        current: list[str],
+        reset_dot: bool = False,
+        parent: str = ''
+    ) -> bool:
         """Parse extended pattern lists."""
 
+        list_type = c
+        index = i.index
+
+        if not i.match(RE_EXT_GROUP):
+            i.rewind(i.index - index)
+            return False
+
         # Save state
+        temp_ext_empty = self.ext_empty
+        bad_sequence = self.bad_sequence
         temp_dir_start = self.dir_start
         temp_after_start = self.after_start
         temp_in_list = self.in_list
         temp_inv_ext = self.inv_ext
         temp_inv_nest = self.inv_nest
+        self.ext_empty = False
         self.in_list = True
-        self.inv_nest = c == '!'
+        self.inv_nest = list_type == '!'
 
         if reset_dot:
             self.match_dot_dir = False
 
         # Start list parsing
         success = True
-        index = i.index
-        list_type = c
         extended = []  # type: list[str]
 
         try:
-            c = next(i)
-            if c != '(':
-                raise StopIteration
-
             while c != ')':
                 c = next(i)
 
-                if self.extend and c in EXT_TYPES and self.parse_extend(c, i, extended):
-                    # Nothing more to do
-                    pass
-                elif c == '*':
+                if not self.extend:
+                    raise StopIteration
+
+                # See if we should parse a nested extended pattern.
+                if c in EXT_TYPES:
+                    if self.parse_extend(c, i, extended, parent=list_type):
+                        continue
+
+                if c == '*':
                     self._handle_star(i, extended)
                 elif c == '.':
                     self._handle_dot(i, extended)
@@ -1599,10 +1595,18 @@ class WcParse(Generic[AnyStr]):
                     if self.pathname:
                         extended.append(self._restrict_extended_slash())
                     extended.append(self.sep)
-                elif c == "|":
-                    if self.inv_nest:
-                        self.clean_up_inverse(extended, temp_inv_nest)
-                    extended.append(c)
+                elif c == '|':
+                    # Add a new slot, but avoid adding more empty slots if we have a known one
+                    if not extended or extended[-1] == '|':
+                        if not self.ext_empty:
+                            extended.append(c)
+                            self.ext_empty = True
+                    else:
+                        extended.append(c)
+                    # Gobble up any empty slots, but avoid adding redundant empty slots
+                    if i.match_next(RE_EMPTY_EXT_SLOTS) and not self.ext_empty:
+                        extended.append('|')
+                        self.ext_empty = True
                     if temp_after_start:
                         self.set_start_dir()
                 elif self.numrange and c == '<':
@@ -1616,11 +1620,12 @@ class WcParse(Generic[AnyStr]):
                         # We've reached the end.
                         # Do nothing because this is going to abort the `extmatch` anyways.
                         pass
-                elif c == '[':
+                elif c == '[' and (self.bad_sequence == -1 or i.index > self.bad_sequence):
                     subindex = i.index
                     try:
                         extended.append(self._sequence(i))
                     except StopIteration:
+                        self.bad_sequence = i.index
                         i.rewind(i.index - subindex)
                         extended.append(r'\[')
                 elif c != ')':
@@ -1628,7 +1633,59 @@ class WcParse(Generic[AnyStr]):
 
                 self.update_dir_state()
 
-            if list_type == '?':
+            # Pop extra pipe if we get an extra one.
+            if len(extended) > 1 and (extended[-1] == '|' == extended[-2]):
+                extended.pop(-1)
+
+            # See if the current content is going into it's own slot, by itself
+            # Additionally, determine if this group is the only child.
+
+            # At the start of a slot?
+            group_start = not current
+            slot_start = group_start or current[-1] == '|'
+            group_end = slot_end = False
+            try:
+                end = next(i)
+                group_end = end == ')'
+                slot_end = group_end or end == '|'
+                i.rewind(1)
+            except StopIteration:
+                pass
+            empty_slot = slot_start and slot_end
+            only_child = parent and group_start and group_end
+            ext_reduce = EXT_REDUCE[list_type]
+            promote_ext = EXT_PROMOTE.get(parent, {})
+
+            # Promote the group type to a different type before final processing.
+            # Child content has already been reduced into this parent.
+            if not self.capture and extended and isinstance(extended[-1], ExtPromote):
+                t = str(extended.pop(-1))
+                list_type = t
+                self.inv_nest = t == '!'
+
+            # Reduce child group into the parent and notify the parent type should change.
+            # Groups must be compatible. e.g. `!(!(a|b))` -> `@(a|b)`.
+            if not self.capture and only_child and list_type in promote_ext:
+                current.extend(extended)
+                t = promote_ext[list_type]
+                current.append(ExtPromote(t))
+                temp_in_list = False
+
+            # Reduce current group into parent group.
+            # When reducing extended groups  `+(a|@(b|c)|d)` -> `+(a|b|c|d)` for
+            # more efficient regular expressions. Nested group must occupy it's own
+            # slot. e.g. `+(a|@(b|c)|d)` not `+(a|test@(b|c)|d)`.
+            # Certain groups cannot be reduced without adding a blank entry.
+            elif not self.capture and parent in ext_reduce['parent'] and empty_slot:
+                current.extend(extended)
+                if parent in ext_reduce['empty'] and not temp_ext_empty:
+                    current.append('|')
+                    if not group_end:
+                        current.append('|')
+                    temp_ext_empty = True
+
+            # Finalize groups of varying types.
+            elif list_type == '?':
                 current.append((_QMARK_CAPTURE_GROUP if self.capture else _QMARK_GROUP).format(''.join(extended)))
             elif list_type == '*':
                 current.append((_STAR_CAPTURE_GROUP if self.capture else _STAR_GROUP).format(''.join(extended)))
@@ -1659,25 +1716,25 @@ class WcParse(Generic[AnyStr]):
                 # so we know which one to use
                 current.append(InvPlaceholder(star))
 
+            # Clean up nested inverse group placeholders and finalize the inverse lookaheads.
             if temp_in_list:
                 self.clean_up_inverse(current, temp_inv_nest and self.inv_nest)
 
         except StopIteration:
             success = False
-            self.inv_ext = temp_inv_ext
             i.rewind(i.index - index)
+            self.extend = False
+            self.inv_ext = temp_inv_ext
+            self.bad_sequence = bad_sequence
+            self.dir_start = temp_dir_start
+            self.after_start = temp_after_start
 
-        # Either restore if extend parsing failed, or reset if it worked
-        if not temp_in_list:
-            self.in_list = False
-        if not temp_inv_nest:
-            self.inv_nest = False
+        self.in_list = temp_in_list
+        self.inv_nest = temp_inv_nest
+        self.ext_empty = temp_ext_empty
 
         if success:
             self.reset_dir_track()
-        else:
-            self.dir_start = temp_dir_start
-            self.after_start = temp_after_start
 
         return success
 
@@ -1740,10 +1797,12 @@ class WcParse(Generic[AnyStr]):
         for c in i:
 
             index = i.index
+
             if self.extend and c in EXT_TYPES and self.parse_extend(c, i, current, True):
-                # Nothing to do
-                pass
-            elif c == '.':
+                self.update_dir_state()
+                continue
+
+            if c == '.':
                 self._handle_dot(i, current)
             elif c == '*':
                 self._handle_star(i, current)
@@ -1774,11 +1833,12 @@ class WcParse(Generic[AnyStr]):
                 except StopIteration:
                     # Escapes nothing, ignore
                     i.rewind(i.index - index)
-            elif c == '[':
+            elif c == '[' and (self.bad_sequence == -1 or i.index > self.bad_sequence):
                 index = i.index
                 try:
                     current.append(self._sequence(i))
                 except StopIteration:
+                    self.bad_sequence = i.index
                     i.rewind(i.index - index)
                     current.append(re.escape(c))
             else:

--- a/wcmatch/fnmatch.py
+++ b/wcmatch/fnmatch.py
@@ -13,24 +13,25 @@ from typing import AnyStr, Iterable, Sequence
 __all__ = (
     "CASE", "EXTMATCH", "IGNORECASE", "RAWCHARS",
     "NEGATE", "MINUSNEGATE", "DOTMATCH", "BRACE", "SPLIT",
-    "NEGATEALL", "FORCEWIN", "FORCEUNIX", "NUMRANGE",
-    "C", "I", "R", "N", "M", "D", "E", "S", "B", "A", "W", "U", "ZN",
+    "NEGATEALL", "FORCEWIN", "FORCEUNIX", "NUMRANGE", "CAPTURE",
+    "C", "I", "R", "N", "M", "D", "E", "S", "B", "A", "W", "U", "ZN", "TC",
     "translate", "fnmatch", "filter", "escape", "is_magic", "compile",
     "WcMatcher"
 )
 
+A = NEGATEALL = _wcparse.NEGATEALL
+B = BRACE = _wcparse.BRACE
 C = CASE = _wcparse.CASE
-I = IGNORECASE = _wcparse.IGNORECASE
-R = RAWCHARS = _wcparse.RAWCHARS
-N = NEGATE = _wcparse.NEGATE
-M = MINUSNEGATE = _wcparse.MINUSNEGATE
 D = DOTMATCH = _wcparse.DOTMATCH
 E = EXTMATCH = _wcparse.EXTMATCH
-B = BRACE = _wcparse.BRACE
+I = IGNORECASE = _wcparse.IGNORECASE
+M = MINUSNEGATE = _wcparse.MINUSNEGATE
+N = NEGATE = _wcparse.NEGATE
+R = RAWCHARS = _wcparse.RAWCHARS
 S = SPLIT = _wcparse.SPLIT
-A = NEGATEALL = _wcparse.NEGATEALL
-W = FORCEWIN = _wcparse.FORCEWIN
+TC = CAPTURE = _wcparse.CAPTURE
 U = FORCEUNIX = _wcparse.FORCEUNIX
+W = FORCEWIN = _wcparse.FORCEWIN
 ZN = NUMRANGE = _wcparse.NUMRANGE
 
 FLAG_MASK = (
@@ -46,7 +47,8 @@ FLAG_MASK = (
     NEGATEALL |
     FORCEWIN |
     FORCEUNIX |
-    NUMRANGE
+    NUMRANGE |
+    CAPTURE
 )
 
 
@@ -97,7 +99,12 @@ def translate(
 ) -> tuple[list[AnyStr], list[AnyStr]]:
     """Translate `fnmatch` pattern."""
 
-    return _wcparse.translate(patterns, _flag_transform(flags), limit, exclude=exclude)
+    return _wcparse.translate(
+        patterns,
+        _flag_transform(flags),
+        limit,
+        exclude=exclude
+    )
 
 
 def fnmatch(
@@ -115,7 +122,12 @@ def fnmatch(
     but if `case_sensitive` is set, respect that instead.
     """
 
-    return _wcparse.compile(patterns, _flag_transform(flags), limit, exclude=exclude).match(filename)
+    return _wcparse.compile(
+        patterns,
+        _flag_transform(flags),
+        limit,
+        exclude=exclude
+    ).match(filename)
 
 
 def filter(  # noqa A001
@@ -128,7 +140,12 @@ def filter(  # noqa A001
 ) -> list[AnyStr]:
     """Filter names using pattern."""
 
-    return _wcparse.compile(patterns, _flag_transform(flags), limit, exclude=exclude).filter(filenames)  # type: ignore[return-value]
+    return _wcparse.compile(
+        patterns,
+        _flag_transform(flags),
+        limit,
+        exclude=exclude
+    ).filter(filenames)  # type: ignore[return-value]
 
 
 def escape(pattern: AnyStr) -> AnyStr:

--- a/wcmatch/glob.py
+++ b/wcmatch/glob.py
@@ -21,9 +21,9 @@ __all__ = (
     "CASE", "IGNORECASE", "RAWCHARS", "DOTGLOB", "DOTMATCH",
     "EXTGLOB", "EXTMATCH", "GLOBSTAR", "NEGATE", "MINUSNEGATE", "BRACE", "NOUNIQUE",
     "REALPATH", "FOLLOW", "MATCHBASE", "MARK", "NEGATEALL", "NODIR", "FORCEWIN", "FORCEUNIX", "GLOBTILDE",
-    "NODOTDIR", "SCANDOTDIR", "SUPPORT_DIR_FD", "GLOBSTARLONG", "NUMRANGE",
+    "NODOTDIR", "SCANDOTDIR", "SUPPORT_DIR_FD", "GLOBSTARLONG", "NUMRANGE", "CAPTURE",
     "C", "I", "R", "D", "E", "G", "N", "M", "B", "P", "L", "S", "X", 'K', "O", "A", "W", "U", "T", "Q", "Z", "SD", "GL",
-    "ZN",
+    "ZN", "TC",
     "iglob", "glob", "globmatch", "globfilter", "escape", "is_magic", "compile",
     "Glob", "WcMatcher"
 )
@@ -34,27 +34,30 @@ WIN = sys.platform.startswith('win')
 
 SUPPORT_DIR_FD = _wcmatch.SUPPORT_DIR_FD
 
+EXT_TYPES = _wcparse.EXT_TYPES
+
+A = NEGATEALL = _wcparse.NEGATEALL
+B = BRACE = _wcparse.BRACE
 C = CASE = _wcparse.CASE
-I = IGNORECASE = _wcparse.IGNORECASE
-R = RAWCHARS = _wcparse.RAWCHARS
 D = DOTGLOB = DOTMATCH = _wcparse.DOTMATCH
 E = EXTGLOB = EXTMATCH = _wcparse.EXTMATCH
 G = GLOBSTAR = _wcparse.GLOBSTAR
-N = NEGATE = _wcparse.NEGATE
-M = MINUSNEGATE = _wcparse.MINUSNEGATE
-B = BRACE = _wcparse.BRACE
-P = REALPATH = _wcparse.REALPATH
-L = FOLLOW = _wcparse.FOLLOW
-S = SPLIT = _wcparse.SPLIT
-X = MATCHBASE = _wcparse.MATCHBASE
-O = NODIR = _wcparse.NODIR
-A = NEGATEALL = _wcparse.NEGATEALL
-W = FORCEWIN = _wcparse.FORCEWIN
-U = FORCEUNIX = _wcparse.FORCEUNIX
-T = GLOBTILDE = _wcparse.GLOBTILDE
-Q = NOUNIQUE = _wcparse.NOUNIQUE
-Z = NODOTDIR = _wcparse.NODOTDIR
 GL = GLOBSTARLONG = _wcparse.GLOBSTARLONG
+I = IGNORECASE = _wcparse.IGNORECASE
+L = FOLLOW = _wcparse.FOLLOW
+M = MINUSNEGATE = _wcparse.MINUSNEGATE
+N = NEGATE = _wcparse.NEGATE
+O = NODIR = _wcparse.NODIR
+P = REALPATH = _wcparse.REALPATH
+Q = NOUNIQUE = _wcparse.NOUNIQUE
+R = RAWCHARS = _wcparse.RAWCHARS
+S = SPLIT = _wcparse.SPLIT
+T = GLOBTILDE = _wcparse.GLOBTILDE
+TC = CAPTURE = _wcparse.CAPTURE
+U = FORCEUNIX = _wcparse.FORCEUNIX
+W = FORCEWIN = _wcparse.FORCEWIN
+X = MATCHBASE = _wcparse.MATCHBASE
+Z = NODOTDIR = _wcparse.NODOTDIR
 ZN = NUMRANGE = _wcparse.NUMRANGE
 
 K = MARK = 0x1000000
@@ -90,6 +93,7 @@ FLAG_MASK = (
     NOUNIQUE |
     NODOTDIR |
     NUMRANGE |
+    CAPTURE |
     _EXTMATCHBASE |
     _NOABSOLUTE
 )
@@ -173,6 +177,7 @@ class _GlobSplit(Generic[AnyStr]):
         self.matchbase = bool(flags & MATCHBASE)
         self.extmatchbase = bool(flags & _wcparse._EXTMATCHBASE)
         self.tilde = bool(flags & GLOBTILDE)
+        self.bad_sequence = -1
         if _wcparse.is_negative(self.pattern, flags):  # pragma: no cover
             # This isn't really used, but we'll keep it around
             # in case we find a reason to directly send inverse patterns
@@ -250,35 +255,44 @@ class _GlobSplit(Generic[AnyStr]):
     def parse_extend(self, c: str, i: util.StringIter) -> bool:
         """Parse extended pattern lists."""
 
-        # Start list parsing
-        success = True
         index = i.index
-        list_type = c
+
+        if not i.match(_wcparse.RE_EXT_GROUP):
+            i.rewind(i.index - index)
+            return False
+
+        success = True
+        bad_sequence = self.bad_sequence
+
         try:
-            c = next(i)
-            if c != '(':
-                raise StopIteration
             while c != ')':
                 c = next(i)
 
-                if self.extend and c in _wcparse.EXT_TYPES and self.parse_extend(c, i):
-                    continue
+                if not self.extend:  # pragma: no cover
+                    raise StopIteration
+
+                #See if we should parse a nested extended pattern.
+                if c in EXT_TYPES:
+                    if self.parse_extend(c, i):
+                        continue
 
                 if c == '\\':
                     try:
                         self._references(i)
                     except StopIteration:
                         pass
-                elif c == '[':
-                    index = i.index
+                elif c == '[' and (self.bad_sequence == -1 or i.index > self.bad_sequence):
+                    index2 = i.index
                     try:
                         self._sequence(i)
                     except StopIteration:
-                        i.rewind(i.index - index)
+                        self.bad_sequence = i.index
+                        i.rewind(i.index - index2)
 
         except StopIteration:
             success = False
-            c = list_type
+            self.extend = False
+            self.bad_sequence = bad_sequence
             i.rewind(i.index - index)
 
         return success
@@ -338,7 +352,7 @@ class _GlobSplit(Generic[AnyStr]):
             i.advance(1)
 
         for c in i:
-            if self.extend and c in _wcparse.EXT_TYPES and self.parse_extend(c, i):
+            if self.extend and c in EXT_TYPES and self.parse_extend(c, i):
                 continue
 
             if c == '\\':
@@ -352,11 +366,12 @@ class _GlobSplit(Generic[AnyStr]):
                     i.rewind(i.index - index)
             elif c == '/':
                 split_index.append((i.index - 1, 0))
-            elif c == '[':
+            elif c == '[' and (self.bad_sequence == -1 or i.index > self.bad_sequence):
                 index = i.index
                 try:
                     self._sequence(i)
                 except StopIteration:
+                    self.bad_sequence = i.index
                     i.rewind(i.index - index)
 
         for split, offset in split_index:
@@ -943,7 +958,14 @@ def compile(  # noqa: A001
 ) -> WcMatcher[AnyStr]:
     """Pre-compile a matcher object."""
 
-    return WcMatcher(_wcparse.compile(patterns, _flag_transform(flags), limit, exclude=exclude))
+    return WcMatcher(
+        _wcparse.compile(
+            patterns,
+            _flag_transform(flags),
+            limit,
+            exclude
+        )
+    )
 
 
 def translate(
@@ -955,7 +977,12 @@ def translate(
 ) -> tuple[list[AnyStr], list[AnyStr]]:
     """Translate glob pattern."""
 
-    return _wcparse.translate(patterns, _flag_transform(flags), limit, exclude)
+    return _wcparse.translate(
+        patterns,
+        _flag_transform(flags),
+        limit,
+        exclude
+    )
 
 
 def globmatch(
@@ -975,7 +1002,12 @@ def globmatch(
     but if `case_sensitive` is set, respect that instead.
     """
 
-    return _wcparse.compile(patterns, _flag_transform(flags), limit, exclude).match(filename, root_dir, dir_fd)
+    return _wcparse.compile(
+        patterns,
+        _flag_transform(flags),
+        limit,
+        exclude
+    ).match(filename, root_dir, dir_fd)
 
 
 def globfilter(
@@ -990,7 +1022,12 @@ def globfilter(
 ) -> list[AnyStr | os.PathLike[AnyStr]]:
     """Filter names using pattern."""
 
-    return _wcparse.compile(patterns, _flag_transform(flags), limit, exclude).filter(filenames, root_dir, dir_fd)
+    return _wcparse.compile(
+        patterns,
+        _flag_transform(flags),
+        limit,
+        exclude
+    ).filter(filenames, root_dir, dir_fd)
 
 
 def escape(pattern: AnyStr, unix: bool | None = None) -> AnyStr:

--- a/wcmatch/pathlib.py
+++ b/wcmatch/pathlib.py
@@ -17,24 +17,24 @@ __all__ = (
     "Path", "PurePath", "WindowsPath", "PosixPath", "PurePosixPath", "PureWindowsPath"
 )
 
+A = NEGATEALL = glob.NEGATEALL
+B = BRACE = glob.BRACE
 C = CASE = glob.CASE
-I = IGNORECASE = glob.IGNORECASE
-R = RAWCHARS = glob.RAWCHARS
 D = DOTGLOB = DOTMATCH = glob.DOTMATCH
 E = EXTGLOB = EXTMATCH = glob.EXTMATCH
 G = GLOBSTAR = glob.GLOBSTAR
-N = NEGATE = glob.NEGATE
-B = BRACE = glob.BRACE
-M = MINUSNEGATE = glob.MINUSNEGATE
-P = REALPATH = glob.REALPATH
+GL = GLOBSTARLONG = glob.GLOBSTARLONG
+I = IGNORECASE = glob.IGNORECASE
 L = FOLLOW = glob.FOLLOW
+M = MINUSNEGATE = glob.MINUSNEGATE
+N = NEGATE = glob.NEGATE
+O = NODIR = glob.NODIR
+P = REALPATH = glob.REALPATH
+Q = NOUNIQUE = glob.NOUNIQUE
+R = RAWCHARS = glob.RAWCHARS
 S = SPLIT = glob.SPLIT
 X = MATCHBASE = glob.MATCHBASE
-O = NODIR = glob.NODIR
-A = NEGATEALL = glob.NEGATEALL
-Q = NOUNIQUE = glob.NOUNIQUE
 Z = NODOTDIR = glob.NODOTDIR
-GL = GLOBSTARLONG = glob.GLOBSTARLONG
 ZN = NUMRANGE = glob.NUMRANGE
 
 SD = SCANDOTDIR = glob.SCANDOTDIR
@@ -129,7 +129,12 @@ class PurePath(pathlib.PurePath):
         Folders and files are essentially matched from right to left.
         """
 
-        return self.globmatch(patterns, flags=flags | _EXTMATCHBASE, limit=limit, exclude=exclude)
+        return self.globmatch(
+            patterns,
+            flags=flags | _EXTMATCHBASE,
+            limit=limit,
+            exclude=exclude
+        )
 
     def globmatch(
         self,
@@ -209,7 +214,13 @@ class Path(pathlib.Path):
             flags = self._translate_flags(  # type: ignore[attr-defined]
                 flags | _NOABSOLUTE
             ) | ((_PATHLIB | SCANDOTDIR) if scandotdir else _PATHLIB)
-            for filename in glob.iglob(patterns, flags=flags, root_dir=str(self), limit=limit, exclude=exclude):
+            for filename in glob.iglob(
+                patterns,
+                flags=flags,
+                root_dir=str(self),
+                limit=limit,
+                exclude=exclude
+            ):
                 yield self.joinpath(filename)
 
     def rglob(  # type: ignore[override]
@@ -230,7 +241,12 @@ class Path(pathlib.Path):
 
         """
 
-        yield from self.glob(patterns, flags=flags | _EXTMATCHBASE, limit=limit, exclude=exclude)
+        yield from self.glob(
+            patterns,
+            flags=flags | _EXTMATCHBASE,
+            limit=limit,
+            exclude=exclude
+        )
 
 
 class PurePosixPath(PurePath, pathlib.PurePosixPath):

--- a/wcmatch/util.py
+++ b/wcmatch/util.py
@@ -144,13 +144,26 @@ class StringIter:
     def __next__(self) -> str:
         """Python 3 iterator compatible next."""
 
-        return self.iternext()
+        try:
+            char = self._string[self._index]
+            self._index += 1
+        except IndexError as e:  # pragma: no cover
+            raise StopIteration from e
+        return char
 
-    def match(self, pattern: Pattern[str]) -> Match[str] | None:
+    def match(self, pattern: Pattern[str], update: bool = True) -> Match[str] | None:
+        """Perform regex match at index."""
+
+        m = pattern.match(self._string, self._index - 1)
+        if m and update:
+            self._index = m.end()
+        return m
+
+    def match_next(self, pattern: Pattern[str], update: bool = True) -> Match[str] | None:
         """Perform regex match at index."""
 
         m = pattern.match(self._string, self._index)
-        if m:
+        if m and update:
             self._index = m.end()
         return m
 
@@ -177,17 +190,6 @@ class StringIter:
             raise ValueError("Can't rewind past beginning!")
 
         self._index -= count
-
-    def iternext(self) -> str:
-        """Iterate through characters of the string."""
-
-        try:
-            char = self._string[self._index]
-            self._index += 1
-        except IndexError as e:  # pragma: no cover
-            raise StopIteration from e
-
-        return char
 
 
 class Immutable:

--- a/wcmatch/wcmatch.py
+++ b/wcmatch/wcmatch.py
@@ -20,13 +20,13 @@ __all__ = (
     "WcMatch"
 )
 
+B = BRACE = _wcparse.BRACE
 C = CASE = _wcparse.CASE
-I = IGNORECASE = _wcparse.IGNORECASE
-R = RAWCHARS = _wcparse.RAWCHARS
 E = EXTMATCH = _wcparse.EXTMATCH
 G = GLOBSTAR = _wcparse.GLOBSTAR
-B = BRACE = _wcparse.BRACE
+I = IGNORECASE = _wcparse.IGNORECASE
 M = MINUSNEGATE = _wcparse.MINUSNEGATE
+R = RAWCHARS = _wcparse.RAWCHARS
 X = MATCHBASE = _wcparse.MATCHBASE
 ZN = NUMRANGE = _wcparse.NUMRANGE
 
@@ -146,7 +146,11 @@ class WcMatch(Generic[AnyStr]):
             if self.matchbase:
                 flags |= MATCHBASE
 
-        return _wcparse.compile([pattern], flags, self.limit) if pattern else None
+        return _wcparse.compile(
+            [pattern],
+            flags,
+            self.limit
+        ) if pattern else None
 
     def _compile(self, file_pattern: AnyStr, folder_exclude_pattern: AnyStr) -> None:
         """Compile patterns."""


### PR DESCRIPTION
- If an EXT group was previously evaluated and shown to be invalid, do not reparse it.
- Additionally, speed up sequence handling as well.
- Flatten extended glob regex where possible.
- Disable extended glob capturing in `translate()` by default, add new flag for backwards compatibility that re-enables it.